### PR TITLE
add 'log' command to get the log records of a given Scrapy Cloud job

### DIFF
--- a/shub/log.py
+++ b/shub/log.py
@@ -1,0 +1,44 @@
+import datetime, click, logging
+#import setuptools # not used in code but needed in runtime, don't remove!
+from scrapinghub import Connection, APIError
+from shub.utils import find_api_key
+
+@click.command(help="get log records of a given job on Scrapy Cloud")
+@click.option("-j", "--jobid", help="the job ID to get the log from", required=True)
+@click.option("-o", "--output-file", help="the file to dump the log into", required=False)
+def cli(jobid, output_file):
+    key = find_api_key()
+    if not key:
+        print "No API key found."
+        return
+    connection = Connection(key)
+    project_id = get_project_id(jobid)
+    project = connection[project_id]
+    try:
+        logitems = project.job(jobid).log()
+    except (APIError, AttributeError), error:
+        print "Error: %s" % error.message
+        return
+    if output_file:
+        with open(output_file, "a") as out:
+            for log_item in logitems:
+                line = get_line(log_item)
+                out.write(line + "\n")
+    else:
+        for log_item in logitems:
+            line = get_line(log_item)
+            print line
+
+def get_line(log_item):
+    message = log_item["message"]
+    level = log_item["level"]
+    timestamp = log_item["time"]
+    date_time = datetime.datetime.fromtimestamp(timestamp/1000)
+    level_name = logging.getLevelName(level)
+    line = "%s [%s] %s" % (date_time, level_name, message)
+    return line
+
+def get_project_id(job_id):
+    if "/" in job_id:
+        return job_id.split("/")[0]
+

--- a/shub/login.py
+++ b/shub/login.py
@@ -1,0 +1,19 @@
+import os, click, json
+
+@click.command(help='create a configuration file for shub')
+def cli():
+    home_cfg = os.path.expanduser('~/.shub.cfg')
+    if os.path.isfile(home_cfg):
+        overwrite = raw_input(
+            'File [%s] already exists. Would you like to overwrite it? [yes/NO]: ' % home_cfg
+        )
+        if overwrite.lower() != 'yes':
+            print 'Quiting...'
+            return
+    config = {
+        'auth': {
+            'key': raw_input('Insert your Scrapy Cloud API key: '),
+        },
+    }
+    with open(home_cfg, 'w') as out:
+        out.write(json.dumps(config, indent=4))

--- a/shub/tool.py
+++ b/shub/tool.py
@@ -14,9 +14,18 @@ def missingmod_cmd(modules):
 def cli():
     pass
 
+# deploy
 m = missing_modules('scrapy', 'setuptools')
 if m:
     cli.add_command(missingmod_cmd(m), 'deploy')
 else:
     from shub import deploy
     cli.add_command(deploy.cli, 'deploy')
+
+# log
+m = missing_modules('scrapinghub')
+if m:
+    cli.add_command(missingmod_cmd(m), 'log')
+else:
+    from shub import log
+    cli.add_command(log.cli, 'log')

--- a/shub/tool.py
+++ b/shub/tool.py
@@ -1,4 +1,4 @@
-import click
+import click, importlib
 from shub.utils import missing_modules
 
 def missingmod_cmd(modules):
@@ -14,18 +14,17 @@ def missingmod_cmd(modules):
 def cli():
     pass
 
-# deploy
-m = missing_modules('scrapy', 'setuptools')
-if m:
-    cli.add_command(missingmod_cmd(m), 'deploy')
-else:
-    from shub import deploy
-    cli.add_command(deploy.cli, 'deploy')
+module_deps = {
+    "deploy": ["scrapy", "setuptools"],
+    "log": ["requests"],
+    "login": [],
+}
 
-# log
-m = missing_modules('scrapinghub')
-if m:
-    cli.add_command(missingmod_cmd(m), 'log')
-else:
-    from shub import log
-    cli.add_command(log.cli, 'log')
+for command, modules in module_deps.iteritems():
+    m = missing_modules(*modules)
+    if m:
+        cli.add_command(missingmod_cmd(m), command)
+    else:
+        module_path = "shub." + command
+        command_class = importlib.import_module(module_path)
+        cli.add_command(command_class.cli, command)

--- a/shub/utils.py
+++ b/shub/utils.py
@@ -1,6 +1,4 @@
-import imp
-import os
-import ConfigParser
+import imp, os, json, ConfigParser
 
 def missing_modules(*modules):
     """Receives a list of module names and returns those which are missing"""
@@ -11,6 +9,17 @@ def missing_modules(*modules):
         except ImportError:
             missing.append(module_name)
     return missing
+
+def get_config():
+    """Returns a dict representing the configuration file's content"""
+    home_cfg = os.path.expanduser("~/.shub.cfg")
+    if os.path.isfile(home_cfg):
+        with open(home_cfg, 'r') as config_file:
+            try:
+                file_content = json.loads(config_file.read())
+            except ValueError:
+                file_content = None
+            return file_content
 
 def find_api_key():
     """Finds and returns the Scrapy Cloud APIKEY"""
@@ -27,7 +36,7 @@ def find_api_key():
     else:
         return
     try:
-        key = reader.get('deploy', 'username')
+        key = reader.get("deploy", "username")
     except (ConfigParser.NoOptionError, ConfigParser.NoSectionError()):
         key = ""
     return key

--- a/shub/utils.py
+++ b/shub/utils.py
@@ -1,4 +1,6 @@
 import imp
+import os
+import ConfigParser
 
 def missing_modules(*modules):
     """Receives a list of module names and returns those which are missing"""
@@ -9,3 +11,23 @@ def missing_modules(*modules):
         except ImportError:
             missing.append(module_name)
     return missing
+
+def find_api_key():
+    """Finds and returns the Scrapy Cloud APIKEY"""
+    key = os.getenv("SH_APIKEY")
+    if key:
+        return key
+    reader = ConfigParser.ConfigParser()
+    home_cfg = os.path.expanduser("~/.scrapy.cfg")
+    local_cfg = os.path.expanduser("scrapy.cfg")
+    if os.path.isfile(local_cfg):
+        reader.read(local_cfg)
+    elif os.path.isfile(home_cfg):
+        reader.read(home_cfg)
+    else:
+        return
+    try:
+        key = reader.get('deploy', 'username')
+    except (ConfigParser.NoOptionError, ConfigParser.NoSectionError()):
+        key = ""
+    return key


### PR DESCRIPTION
@pablohoffman, do you intend to support common operations in Scrapy Cloud, like scheduling and getting the log records of a given job? If your answer is yes, here is a PR that uses the [scrapinghub] (https://github.com/scrapinghub/python-scrapinghub) library do get the log records of a given job.

Please, take a look at the line 2 of shub/log.py (copied from deploy.py). Is __setuptools__ needed in all commands or it's a just a __deploy__ specific requirement?
