### PR TITLE
Fix encoding issues when "shub deploy" is called with a custom "--version" argument.

### DIFF
--- a/shub/deploy.py
+++ b/shub/deploy.py
@@ -130,7 +130,7 @@ def _get_version(target, version):
         b = p.communicate()[0].strip('\n')
         return '%s-%s' % (d, b)
     elif version:
-        return version
+        return str(version)
     else:
         return str(int(time.time()))
 


### PR DESCRIPTION
version should be a bytestring when passed as a header value.
