### PR TITLE
Adding 'requests' as requirement in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     },
     include_package_data=True,
     zip_safe=False,
-    install_requires=['click'],
+    install_requires=['click', 'requests'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
After ``pip install shub``, shub fails to run due to the missing module
``requests``, as it does not get installed due to not being included in
``install_requires`` of ``setup.py``.

However, ``requests`` does get installed when running ``python setup.py
install``.

Might be nicer for users if ``requests`` gets installed right away. 