### PR TITLE
fix "--build-egg" option

### DIFF
--- a/shub/deploy.py
+++ b/shub/deploy.py
@@ -39,7 +39,7 @@ setup(
 @click.option("-l", "--list-targets", help="list available targets", is_flag=True)
 @click.option("-d", "--debug", help="debug mode (do not remove build dir)", is_flag=True)
 @click.option("--egg", help="deploy the given egg, instead of building one")
-@click.option("--build-egg", help="only build the egg, don't deploy it", is_flag=True)
+@click.option("--build-egg", help="only build the given egg, don't deploy it")
 def cli(target, project, version, list_targets, debug, egg, build_egg):
     exitcode = 0
     if not inside_project():


### PR DESCRIPTION
which originally(in scrapy.commands.deploy) received a file and seems to be copypasted without checking