### PR TITLE
Fix: avoid editable src leftover from pip -e for git dependencies

### DIFF
--- a/shub/deploy_reqs.py
+++ b/shub/deploy_reqs.py
@@ -1,6 +1,7 @@
 import click
 import os
 import tempfile
+import shutil
 
 from shub.utils import run, decompress_egg_files
 from shub import utils
@@ -31,5 +32,13 @@ def _mk_and_cd_eggs_tmpdir():
 
 
 def _download_egg_files(eggs_dir, requirements_file):
-    pip_cmd = "pip install -d %s -r %s --no-deps --no-use-wheel"
-    print(run(pip_cmd % (eggs_dir, requirements_file)))
+    editable_src_dir = tempfile.mkdtemp(prefix='pipsrc')
+
+    try:
+        pip_cmd = ("pip install -d {eggs_dir} -r {requirements_file}"
+                   " --src {editable_src_dir} --no-deps --no-use-wheel")
+        print(run(pip_cmd.format(eggs_dir=eggs_dir,
+                                 editable_src_dir=editable_src_dir,
+                                 requirements_file=requirements_file)))
+    finally:
+        shutil.rmtree(editable_src_dir, ignore_errors=True)


### PR DESCRIPTION
When downloading git dependencies with pip, pip would create a `src` directory with the editable sources and put the `pip-delete-this-directory.txt` file.

This messes up the behavior of `utils.build_and_deploy_eggs`, which expects to find only directories for packages inside the `eggs` directory.

This fixes the problem by using [pip's `--src` option][1] to use a temporary dir for the editable sources, this way the eggs dir will be as expected (containing only extracted packages).

[1]: https://pip.pypa.io/en/latest/reference/pip_install.html#install-src