### PR TITLE
fix return code for _upload_egg

### DIFF
--- a/shub/deploy.py
+++ b/shub/deploy.py
@@ -140,7 +140,7 @@ def _upload_egg(target, eggpath, project, version):
     auth = _get_auth(target)
 
     log('Deploying to Scrapy Cloud project "%s"' % project)
-    make_deploy_request(url, data, files, auth)
+    return make_deploy_request(url, data, files, auth)
 
 
 def _get_auth(target):


### PR DESCRIPTION
Hey fellows,

The exit status was always `1` when running `shub deploy` -- this fixes it.