### PR TITLE
Fix tests for python3 using decode() on pipe output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: python
 python: 2.7
 env:
 - TOXENV=py27
+- TOXENV=pypy
+- TOXENV=py33
+- TOXENV=py34
 install:
 - "./.travis-workarounds.sh"
 - pip install -U tox

--- a/shub/deploy_reqs.py
+++ b/shub/deploy_reqs.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import click
 import os
 import tempfile

--- a/shub/login.py
+++ b/shub/login.py
@@ -10,7 +10,7 @@ def cli(context):
     if key and is_valid_key(key):
         descriptor = os.open(
             NETRC_FILE,
-            os.O_CREAT | os.O_RDWR | os.O_APPEND, 0600)
+            os.O_CREAT | os.O_RDWR | os.O_APPEND, 0o600)
         with os.fdopen(descriptor, 'a+') as out:
             line = 'machine scrapinghub.com login {0} password ""\n'.format(key)
             out.write(line)

--- a/shub/tool.py
+++ b/shub/tool.py
@@ -26,7 +26,7 @@ module_deps = {
     "version": [],
 }
 
-for command, modules in module_deps.iteritems():
+for command, modules in module_deps.items():
     m = missing_modules(*modules)
     if m:
         cli.add_command(missingmod_cmd(m), command)

--- a/tests/test_logout.py
+++ b/tests/test_logout.py
@@ -1,6 +1,8 @@
-import unittest, os
-from shub.logout import remove_sh_key
+import os
+import unittest
 from tempfile import NamedTemporaryFile
+from shub.logout import remove_sh_key
+
 
 class LogoutTestCase(unittest.TestCase):
     _netrc_file = None
@@ -18,7 +20,7 @@ class LogoutTestCase(unittest.TestCase):
     def _create_tmp_netrc(self):
         with NamedTemporaryFile(delete=False) as netrc:
             line = 'machine scrapinghub.com login ffffffffffffffffffffffffffffffff password ""'
-            netrc.write(line)
+            netrc.write(line.encode())
         return netrc.name
 
     def _delete_tmp_netrc(self, netrc_file):

--- a/tests/test_logout.py
+++ b/tests/test_logout.py
@@ -20,7 +20,7 @@ class LogoutTestCase(unittest.TestCase):
     def _create_tmp_netrc(self):
         with NamedTemporaryFile(delete=False) as netrc:
             line = 'machine scrapinghub.com login ffffffffffffffffffffffffffffffff password ""'
-            netrc.write(line.encode())
+            netrc.write(line.encode('ascii'))
         return netrc.name
 
     def _delete_tmp_netrc(self, netrc_file):


### PR DESCRIPTION
Hey folks,

So, this needs more testing, it just adds some tricks to fix the current tests for Python 3, I'm not sure how much this means for Python 3 compatibility yet.

This basically just adds `.decode()` to the places where are expected bytes in Python 3 (pipe outputs) -- plus some minor refactorings.

The encoding should be `ascii` for all outputs, not sure if I should be explicit about it.

@kmike any advice here? :)