### PR TITLE
Add rudimentary end to end tests

### DIFF
--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -4,8 +4,11 @@
 import unittest
 from click.testing import CliRunner
 from shub import tool
+import os
 
 
+@unittest.skipUnless(os.getenv('USING_TOX'),
+                     'End to end tests only run via TOX')
 class ShubEndToEndTests(unittest.TestCase):
     def setUp(self):
         self.runner = CliRunner()

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+# coding=utf-8
+
+import unittest
+from click.testing import CliRunner
+from shub import tool
+
+
+class ShubEndToEndTests(unittest.TestCase):
+    def setUp(self):
+        self.runner = CliRunner()
+
+    def run_subcmd(self, subcmd):
+        return self.runner.invoke(tool.cli, [subcmd]).output
+
+    def test_usage_is_displayed_if_no_arg_is_provided(self):
+        output = self.run_subcmd('')
+        usage_is_displayed = output.startswith('Usage:')
+        self.assertTrue(usage_is_displayed)
+
+    def test_deploy_egg_isnt_broken(self):
+        output = self.run_subcmd('deploy-egg')
+        error = 'Unexpected output: %s' % output
+        self.assertTrue('Missing argument' in output, error)
+
+    def test_deploy_reqs_isnt_broken(self):
+        output = self.run_subcmd('deploy-reqs')
+        error = 'Unexpected output: %s' % output
+        self.assertTrue('Missing argument' in output, error)
+
+    def test_deploy_isnt_broken(self):
+        output = self.run_subcmd('deploy')
+        error = 'Unexpected output: %s' % output
+        self.assertTrue('requires scrapy' in output, error)
+
+    def test_fetch_eggs_isnt_broken(self):
+        output = self.run_subcmd('fetch-eggs')
+        error = 'Unexpected output: %s' % output
+        self.assertTrue('Missing argument' in output, error)

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,12 @@
 envlist = py27, pypy, py33, py34
 
 [testenv]
+setenv =
+    USING_TOX=1
+
 deps =
     -rrequirements.txt
     mock
     pytest
 commands =
-    py.test {posargs:}
+    py.test -v {posargs:}


### PR DESCRIPTION
Our subcommand tests bypass the click wrappers. I think it's a good idea
to have at least these very simple end to end tests (although not very useful) just to have a little more confidence that no silly bugs have gone unnoticed.

For example, this commit https://github.com/scrapinghub/shub/commit/e73c4e34bceaf8a3469a42a0167306a46e8ef7d7 didn't allow the subcommands to be run, although ```shub```, ```shub --version``` and ```shub version``` were running fine (I tried those when testing the above PR =/).