### PR TITLE
Deploy falling back to standard login credentials

### DIFF
--- a/shub/deploy.py
+++ b/shub/deploy.py
@@ -16,8 +16,11 @@ from scrapy.utils.project import inside_project
 from scrapy.utils.python import retry_on_eintr
 from scrapy.utils.conf import get_config, closest_scrapy_cfg
 
+from shub import login
+
 from shub.click_utils import log, fail
-from shub.utils import make_deploy_request, pwd_hg_version, pwd_git_version
+from shub.utils import (make_deploy_request, pwd_hg_version, pwd_git_version,
+                        find_api_key)
 
 
 _SETUP_PY_TEMPLATE = """\
@@ -149,8 +152,13 @@ def _get_auth(target):
     # try netrc
     try:
         host = urlparse(target['url']).hostname
-        a = netrc.netrc().authenticators(host)
-        return (a[0], a[2])
+        auth = netrc.netrc().authenticators(host)
+        if auth:
+            return (auth[0], auth[2])
+
+        if host.endswith(login.SH_TOP_LEVEL_DOMAIN):
+            return (find_api_key(), '')
+
     except (netrc.NetrcParseError, IOError, TypeError):
         pass
 

--- a/shub/login.py
+++ b/shub/login.py
@@ -1,5 +1,10 @@
-import os, re, click
+import os
+import re
+import click
 from shub.utils import get_key_netrc, NETRC_FILE
+
+SH_TOP_LEVEL_DOMAIN = 'scrapinghub.com'
+
 
 @click.command(help='add Scrapinghug API key into the netrc file')
 @click.pass_context
@@ -12,10 +17,12 @@ def cli(context):
             NETRC_FILE,
             os.O_CREAT | os.O_RDWR | os.O_APPEND, 0600)
         with os.fdopen(descriptor, 'a+') as out:
-            line = 'machine scrapinghub.com login {0} password ""\n'.format(key)
+            line = 'machine {0} login {1} password ""\n'.format(
+                SH_TOP_LEVEL_DOMAIN, key)
             out.write(line)
     else:
         context.fail('Invalid key')
+
 
 def is_valid_key(key):
     return bool(re.match(r'[A-Fa-f\d]{32}$', key))


### PR DESCRIPTION
It was looking only for scrapy.cfg files. Now it also looks for the
~/.netrc file and $SHUB_APIKEY.

Fixes #35 