### PR TITLE
Raising exception on utils#find_api_key

### DIFF
--- a/shub/utils.py
+++ b/shub/utils.py
@@ -36,10 +36,20 @@ def missing_modules(*modules):
 
 
 def find_api_key():
-    """Finds and returns the Scrapy Cloud APIKEY"""
+    """Finds and returns the Scrapy Cloud APIKEY
+
+    Raises:
+        ClickException: if no API key is found
+    """
     key = os.getenv("SHUB_APIKEY")
     if not key:
         key = get_key_netrc()
+
+    if not key:
+        err = ("Your credentials haven't been defined.\n"
+               "Use 'shub login' or set the SHUB_APIKEY environment variable.")
+        raise ClickException(err)
+
     return key
 
 

--- a/tests/test_deploy_egg.py
+++ b/tests/test_deploy_egg.py
@@ -28,6 +28,7 @@ class TestDeployEgg(unittest.TestCase):
 
         self.fake_requester = FakeRequester()
         deploy_egg.utils.make_deploy_request = self.fake_requester.fake_request
+        deploy_egg.utils.find_api_key = lambda: ''
 
         self.tmp_dir = tempfile.mktemp(prefix="shub-test-deploy-eggs")
 

--- a/tests/test_fetch_eggs.py
+++ b/tests/test_fetch_eggs.py
@@ -11,16 +11,19 @@ FakeResponse = namedtuple('FakeResponse', ['status_code'])
 class FetchEggsTest(unittest.TestCase):
 
     def setUp(self):
-        self.runner = CliRunner()
+        # defining SHUB_APIKEY so it passes the login validation
+        self.runner = CliRunner(env={'SHUB_APIKEY': 'xxx'})
 
     def test_raises_auth_exception(self, requests_mock):
         fake_response = FakeResponse(403)
         requests_mock.get.return_value = fake_response
         output = self.runner.invoke(tool.cli, ['fetch-eggs', 'xxx']).output
-        self.assertTrue('Authentication failure' in output)
+        err = 'Unexpected output: %s' % output
+        self.assertTrue('Authentication failure' in output, err)
 
     def test_raises_exception_if_request_error(self, requests_mock):
         fake_response = FakeResponse(400)
         requests_mock.get.return_value = fake_response
         output = self.runner.invoke(tool.cli, ['fetch-eggs', 'xxx']).output
-        self.assertTrue('Eggs could not be fetched' in output)
+        err = 'Unexpected output: %s' % output
+        self.assertTrue('Eggs could not be fetched' in output, err)


### PR DESCRIPTION
NoCredentialsException is a ClickException, which is handled nicely by
click, displaying the error msg and returning an exit code != 0.

Fixes #32 and #34 