### PR TITLE
'shub deploy' using the apikey set by 'shub login'

### DIFF
--- a/shub/auth.py
+++ b/shub/auth.py
@@ -1,0 +1,48 @@
+import os
+import netrc
+
+from os.path import expanduser
+
+from click import ClickException
+
+OS_WIN = True if os.name == 'nt' else False
+NETRC_FILE = expanduser('~/_netrc') if OS_WIN else expanduser('~/.netrc')
+
+
+def find_api_key():
+    """
+    Raises:
+        ClickException: if no credentials are found
+    """
+    key = os.getenv("SHUB_APIKEY")
+    if not key:
+        key = get_key_netrc()
+
+    if not key:
+        err = 'Not logged in. Please login first with: shub login'
+        raise ClickException(err)
+
+    return key
+
+
+def get_key_netrc():
+    """Gets the key from the netrc file"""
+    try:
+        info = netrc.netrc(NETRC_FILE)
+    except IOError:
+        return
+    try:
+        key, account, password = info.authenticators("scrapinghub.com")
+    except TypeError:
+        return
+    if key:
+        return key
+
+
+def write_key_netrc(key):
+    descriptor = os.open(
+        NETRC_FILE,
+        os.O_CREAT | os.O_RDWR | os.O_APPEND, 0o600)
+    with os.fdopen(descriptor, 'a+') as out:
+        line = 'machine scrapinghub.com login {0} password ""\n'.format(key)
+        out.write(line)

--- a/shub/fetch_eggs.py
+++ b/shub/fetch_eggs.py
@@ -2,7 +2,7 @@ import click
 import requests
 from click import ClickException
 
-from shub.utils import find_api_key
+from shub.auth import find_api_key
 from shub.click_utils import log
 from shub.exceptions import AuthException
 

--- a/shub/login.py
+++ b/shub/login.py
@@ -1,19 +1,15 @@
-import os, re, click
-from shub.utils import get_key_netrc, NETRC_FILE
+import re, click
+from shub import auth
 
 @click.command(help='add Scrapinghug API key into the netrc file')
 @click.pass_context
 def cli(context):
-    if get_key_netrc():
+    if auth.get_key_netrc():
         context.fail('Key already exists in netrc file')
     key = raw_input('Insert your Scrapinghub API key: ')
+
     if key and is_valid_key(key):
-        descriptor = os.open(
-            NETRC_FILE,
-            os.O_CREAT | os.O_RDWR | os.O_APPEND, 0o600)
-        with os.fdopen(descriptor, 'a+') as out:
-            line = 'machine scrapinghub.com login {0} password ""\n'.format(key)
-            out.write(line)
+        auth.write_key_netrc(key)
     else:
         context.fail('Invalid key')
 

--- a/shub/logout.py
+++ b/shub/logout.py
@@ -1,5 +1,5 @@
 import re, click
-from shub.utils import get_key_netrc, NETRC_FILE
+from shub.auth import get_key_netrc, NETRC_FILE
 
 @click.command(help='remove Scrapinghug API key from the netrc file')
 @click.pass_context

--- a/shub/utils.py
+++ b/shub/utils.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 import imp
 import os
-import netrc
 import subprocess
 import sys
 
@@ -13,13 +12,11 @@ import requests
 
 from click import ClickException
 
+from shub.auth import find_api_key
 from shub.click_utils import log
 from shub.exceptions import AuthException
 
 SCRAPY_CFG_FILE = os.path.expanduser("~/.scrapy.cfg")
-OS_WIN = True if os.name == 'nt' else False
-NETRC_FILE = os.path.expanduser('~/_netrc') if OS_WIN else os.path.expanduser('~/.netrc')
-
 FALLBACK_ENCODING = 'utf-8'
 STDOUT_ENCODING = sys.stdout.encoding or FALLBACK_ENCODING
 
@@ -34,37 +31,6 @@ def missing_modules(*modules):
             missing.append(module_name)
     return missing
 
-
-def find_api_key():
-    """Finds and returns the Scrapy Cloud APIKEY
-
-    Raises:
-        ClickException: if no API key is found
-    """
-    key = os.getenv("SHUB_APIKEY")
-    if not key:
-        key = get_key_netrc()
-
-    if not key:
-        err = ("Your credentials haven't been defined.\n"
-               "Use 'shub login' or set the SHUB_APIKEY environment variable.")
-        raise ClickException(err)
-
-    return key
-
-
-def get_key_netrc():
-    """Gets the key from the netrc file"""
-    try:
-        info = netrc.netrc(NETRC_FILE)
-    except IOError:
-        return
-    try:
-        key, account, password = info.authenticators("scrapinghub.com")
-    except TypeError:
-        return
-    if key:
-        return key
 
 def make_deploy_request(url, data, files, auth):
     try:


### PR DESCRIPTION
As discussed on #36, all commands should be in the login/logout workflow.

Fixes #35 

I'll make another PR to facilitate the login reading api keys in scrapy.cfg files.