### PR TITLE
Lower the precedence of $SHUB_APIKEY

### DIFF
--- a/shub/auth.py
+++ b/shub/auth.py
@@ -14,9 +14,10 @@ def find_api_key():
     Raises:
         ClickException: if no credentials are found
     """
-    key = os.getenv("SHUB_APIKEY")
+    key = get_key_netrc()
+
     if not key:
-        key = get_key_netrc()
+        key = os.getenv("SHUB_APIKEY")
 
     if not key:
         err = 'Not logged in. Please login first with: shub login'


### PR DESCRIPTION
Giving higher precedence to the .netrc API key will avoid confusion for
those who have $SHUB_APIKEY set and have also logged in with 'shub login'.

This should be merged after #41 