### PR TITLE
Fix the "unknown" egg versions problem in deploy-reqs

### DIFF
--- a/shub/deploy_reqs.py
+++ b/shub/deploy_reqs.py
@@ -2,7 +2,6 @@ from __future__ import print_function
 import click
 import os
 import tempfile
-import shutil
 
 from shub.utils import run, decompress_egg_files
 from shub.click_utils import log
@@ -36,14 +35,8 @@ def _mk_and_cd_eggs_tmpdir():
 
 
 def _download_egg_files(eggs_dir, requirements_file):
-    editable_src_dir = tempfile.mkdtemp(prefix='pipsrc')
-
     log('Downloading eggs...')
-    try:
-        pip_cmd = ("pip install -d {eggs_dir} -r {requirements_file}"
-                   " --src {editable_src_dir} --no-deps --no-use-wheel")
-        log(run(pip_cmd.format(eggs_dir=eggs_dir,
-                                 editable_src_dir=editable_src_dir,
-                                 requirements_file=requirements_file)))
-    finally:
-        shutil.rmtree(editable_src_dir, ignore_errors=True)
+    pip_cmd = ("pip install -d {eggs_dir} -r {requirements_file}"
+               " --no-deps --no-use-wheel")
+    log(run(pip_cmd.format(eggs_dir=eggs_dir,
+                           requirements_file=requirements_file)))

--- a/shub/utils.py
+++ b/shub/utils.py
@@ -96,9 +96,20 @@ def decompress_egg_files():
         log("Uncompressing: %s" % egg)
         run("%s %s" % (decompressor_by_ext[_ext(egg)], egg))
 
+def _is_egg_dir(f):
+    if not isdir(f):
+        return False
 
+    files = os.listdir(f)
+
+    # these folders are usually created by PIP when the egg is
+    # checked out from a VCS.
+    # check ssues #21 and #44 for more details
+    pip_tmp_dir = 'pip-delete-this-directory.txt' in files
+
+    return 'setup.py' in files and not pip_tmp_dir
 def build_and_deploy_eggs(project_id, apikey):
-    egg_dirs = (f for f in glob('*') if isdir(f))
+    egg_dirs = (f for f in glob('*') if _is_egg_dir(f))
 
     for egg_dir in egg_dirs:
         os.chdir(egg_dir)


### PR DESCRIPTION
Reverts #21 and fixes #44 

Instead of using an alternate src dir, now we just ignore the folders
that don't look like egg dirs. The only know case for this is when we
try to install packages from git and the src dir is left in the same
folder as the eggs folders. So, it shouldn't be an issue.