### PR TITLE
[MRG+1] Fix version names when setup.py --version returns many lines

### DIFF
--- a/shub/utils.py
+++ b/shub/utils.py
@@ -164,7 +164,8 @@ def _get_dependency_version(name):
     elif isdir('.bzr'):
         return pwd_bzr_version()
 
-    return "%s-%s" % (name, _last_line_of(run('python setup.py --version')))
+    version = _last_line_of(run('python setup.py --version'))
+    return "%s-%s" % (name, version)
 
 
 def _get_egg_info(name):

--- a/shub/utils.py
+++ b/shub/utils.py
@@ -147,10 +147,13 @@ def _deploy_dependency_egg(apikey, project_id):
     success = "Deployed eggs list at: https://dash.scrapinghub.com/p/%s/eggs"
     log(success % project_id)
 
+def _last_line_of(s):
+    return s.split('\n')[-1]
+
 
 def _get_dependency_name():
     # In some cases, python setup.py --name returns more than one line, so we use the last one to get the name
-    return run('python setup.py --name').split("\n")[-1]
+    return _last_line_of(run('python setup.py --name'))
 
 
 def _get_dependency_version(name):
@@ -161,7 +164,7 @@ def _get_dependency_version(name):
     elif isdir('.bzr'):
         return pwd_bzr_version()
 
-    return "%s-%s" % (name, run('python setup.py --version'))
+    return "%s-%s" % (name, _last_line_of(run('python setup.py --version')))
 
 
 def _get_egg_info(name):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# coding=utf-8
+
+
+import unittest
+from mock import patch
+from shub import utils
+from click.testing import CliRunner
+
+
+class UtilsTest(unittest.TestCase):
+    def setUp(self):
+        self.runner = CliRunner()
+
+    def test_dependency_version_from_setup_is_parsed_properly(self):
+        def check(cmd):
+            if cmd == 'python setup.py --version':
+                return setup_version
+
+        setup_version = ('Building lxml version 3.4.4.'
+                         '\nBuilding without Cython.'
+                         '\nUsing build configuration of libxslt 1.1.28'
+                         '\n3.4.4')
+
+        with self.runner.isolated_filesystem():
+            with patch('shub.utils.run', side_effect=check) as mocked_run:
+                # given
+                mocked_run.return_value = setup_version
+                # when
+                version = utils._get_dependency_version('lxml')
+                # then
+                self.assertEquals('lxml-3.4.4', version)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This fixes the version names in the same way that
e6f0b1767b093791f457928d2d70bd32764fcf6a fixes the problem with egg
names in #49