### PR TITLE
Replaced `imp` by `importlib` because `imp` fails to import zipped eggs.

### DIFF
--- a/shub/utils.py
+++ b/shub/utils.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-import imp
+import importlib
 import os
 import subprocess
 import sys
@@ -26,7 +26,7 @@ def missing_modules(*modules):
     missing = []
     for module_name in modules:
         try:
-            imp.find_module(module_name)
+            importlib.import_module(module_name)
         except ImportError:
             missing.append(module_name)
     return missing


### PR DESCRIPTION
The function `imp.find_module` fails when the given module is installed as a zipped egg, see the session below. Also another reason to drop `imp` in favour is because it was deprecated in python 3.4.

This error makes `shub deploy` unusable when setuptools is installed as egg (i.e. when using conda in OS X).

```
Python 2.7.10 |Continuum Analytics, Inc.| (default, May 28 2015, 17:04:42)
[GCC 4.2.1 (Apple Inc. build 5577)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
Anaconda is brought to you by Continuum Analytics.
Please check out: http://continuum.io/thanks and https://binstar.org
>>> import setuptools
>>> setuptools.__file__
'/Users/rolando/miniconda/envs/myproject/lib/python2.7/site-packages/setuptools-18.0.1-py2.7.egg/setuptools/__init__.py'
>>> import imp
>>> imp.find_module('setuptools')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: No module named setuptools
```