### PR TITLE
Stop returning an error for logged in login attempts

### DIFF
--- a/shub/login.py
+++ b/shub/login.py
@@ -10,7 +10,8 @@ from six.moves import input
 @click.pass_context
 def cli(context):
     if auth.get_key_netrc():
-        context.fail('Already logged in. To logout use: shub logout')
+        log("You're already logged in. To change credentials, use 'shub logout' first.")
+        return 0
 
     cfg_key = _find_cfg_key()
     key = _prompt_for_key(suggestion=cfg_key)

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -65,3 +65,17 @@ username = KEY_SUGGESTION
 
             # then
             self.assertEqual(0, result.exit_code, result.exception)
+
+    def test_login_attempt_after_login_doesnt_lead_to_an_error(self):
+        with self.runner.isolated_filesystem() as fs:
+            login.auth.NETRC_FILE = os.path.join(fs, '.netrc')
+
+            # given
+            self.runner.invoke(login.cli, input=self.VALID_KEY)
+
+            # when
+            result = self.runner.invoke(login.cli, input=self.VALID_KEY)
+
+            # then
+            self.assertEqual(0, result.exit_code)
+            self.assertTrue('already logged in' in result.output)


### PR DESCRIPTION
Now we just advise the user to logout first if he wants to change the
credentials.

Fixes #46