### PR TITLE
Use requirements.txt as default for deploy_reqs

### DIFF
--- a/shub/deploy_reqs.py
+++ b/shub/deploy_reqs.py
@@ -7,18 +7,22 @@ import shutil
 from shub.utils import run, decompress_egg_files
 from shub.click_utils import log
 from shub import utils
+from shub import scrapycfg
 from shub.auth import find_api_key
 
 
 @click.command(help="Build and deploy eggs from requirements.txt")
-@click.argument("project_id", required=True)
+@click.option("-p", "--project", help="the project ID to deploy to",
+              type=click.INT)
 @click.argument("requirements_file", required=True)
-def cli(project_id, requirements_file):
+def cli(project, requirements_file):
     """Just a wrapper around the deploy_egg module"""
-    main(project_id, requirements_file)
+    main(project, requirements_file)
 
 
 def main(project_id, requirements_file):
+    target = scrapycfg.get_target('default')
+    project_id = scrapycfg.get_project(target, project_id)
     apikey = find_api_key()
     requirements_full_path = os.path.abspath(requirements_file)
     eggs_tmp_dir = _mk_and_cd_eggs_tmpdir()
@@ -43,7 +47,7 @@ def _download_egg_files(eggs_dir, requirements_file):
         pip_cmd = ("pip install -d {eggs_dir} -r {requirements_file}"
                    " --src {editable_src_dir} --no-deps --no-use-wheel")
         log(run(pip_cmd.format(eggs_dir=eggs_dir,
-                                 editable_src_dir=editable_src_dir,
-                                 requirements_file=requirements_file)))
+                               editable_src_dir=editable_src_dir,
+                               requirements_file=requirements_file)))
     finally:
         shutil.rmtree(editable_src_dir, ignore_errors=True)

--- a/shub/deploy_reqs.py
+++ b/shub/deploy_reqs.py
@@ -14,7 +14,8 @@ from shub.auth import find_api_key
 @click.command(help="Build and deploy eggs from requirements.txt")
 @click.option("-p", "--project", help="the project ID to deploy to",
               type=click.INT)
-@click.argument("requirements_file", required=True)
+@click.option("-r", "--requirements-file", default='requirements.txt',
+              type=click.STRING)
 def cli(project, requirements_file):
     """Just a wrapper around the deploy_egg module"""
     main(project, requirements_file)

--- a/shub/deploy_reqs.py
+++ b/shub/deploy_reqs.py
@@ -24,6 +24,8 @@ def main(project_id, requirements_file):
     target = scrapycfg.get_target('default')
     project_id = scrapycfg.get_project(target, project_id)
     apikey = find_api_key()
+    log('Deploying requirements to project "%s"' % project_id)
+
     requirements_full_path = os.path.abspath(requirements_file)
     eggs_tmp_dir = _mk_and_cd_eggs_tmpdir()
     _download_egg_files(eggs_tmp_dir, requirements_full_path)

--- a/tests/test_deploy_reqs.py
+++ b/tests/test_deploy_reqs.py
@@ -18,7 +18,9 @@ class TestDeployReqs(unittest.TestCase):
 
     def setUp(self):
         self.runner = CliRunner()
-        os.environ['SHUB_APIKEY'] = self.VALID_APIKEY
+
+    def cli_run(self, cli, args):
+        return self.runner.invoke(cli, args, env={'SHUB_APIKEY': self.VALID_APIKEY})
 
     def test_can_decompress_downloaded_packages_and_call_deploy_reqs(self, deploy_egg_mock):
         # GIVEN
@@ -26,7 +28,7 @@ class TestDeployReqs(unittest.TestCase):
 
         with self.runner.isolated_filesystem():
             # WHEN
-            result = self.runner.invoke(deploy_reqs.cli, ["-p -1", requirements_file])
+            result = self.cli_run(deploy_reqs.cli, ["-p -1", requirements_file])
 
             # THEN
             self.assertEqual(2, deploy_egg_mock.call_count, self.error_for(result))
@@ -38,7 +40,7 @@ class TestDeployReqs(unittest.TestCase):
             self.write_valid_scrapy_cfg()
 
             # WHEN I don't provide the project id
-            self.runner.invoke(deploy_reqs.cli, [requirements_file])
+            self.cli_run(deploy_reqs.cli, [requirements_file])
 
             # THEN It uses the project id in the scrapy.cfg file
             deploy_egg_mock.assert_called_with('-1', self.VALID_APIKEY)

--- a/tests/test_deploy_reqs.py
+++ b/tests/test_deploy_reqs.py
@@ -6,7 +6,7 @@ from __future__ import print_function
 import unittest
 import os
 import tempfile
-from mock import Mock, patch
+from mock import patch
 from click.testing import CliRunner
 
 from shub import deploy_reqs
@@ -28,7 +28,8 @@ class TestDeployReqs(unittest.TestCase):
 
         with self.runner.isolated_filesystem():
             # WHEN
-            result = self.cli_run(deploy_reqs.cli, ["-p -1", requirements_file])
+            args = ["-p 123", '--requirements-file=%s' % requirements_file]
+            result = self.cli_run(deploy_reqs.cli, args)
 
             # THEN
             self.assertEqual(2, deploy_egg_mock.call_count, self.error_for(result))
@@ -40,7 +41,7 @@ class TestDeployReqs(unittest.TestCase):
             self.write_valid_scrapy_cfg()
 
             # WHEN I don't provide the project id
-            self.cli_run(deploy_reqs.cli, [requirements_file])
+            self.cli_run(deploy_reqs.cli, ['--requirements-file=%s' % requirements_file])
 
             # THEN It uses the project id in the scrapy.cfg file
             deploy_egg_mock.assert_called_with('-1', self.VALID_APIKEY)

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -29,7 +29,7 @@ class ShubEndToEndTests(unittest.TestCase):
     def test_deploy_reqs_isnt_broken(self):
         output = self.run_subcmd('deploy-reqs')
         error = 'Unexpected output: %s' % output
-        self.assertTrue('Missing argument' in output, error)
+        self.assertTrue('Missing project id' in output, error)
 
     def test_deploy_isnt_broken(self):
         output = self.run_subcmd('deploy')


### PR DESCRIPTION
As that's usually the case. Alternative files can be defined via -r or
--requirements-file parameter

This should be merged after #54