### PR TITLE
Fix bdist fallback when setup.py references __file__

### DIFF
--- a/shub/utils.py
+++ b/shub/utils.py
@@ -127,7 +127,7 @@ def build_and_deploy_egg(project_id, apikey):
     except CalledProcessError:
         # maybe a C extension or distutils package, forcing bdist_egg
         log("Couldn't build an egg with vanilla setup.py, trying with setuptools...")
-        run('python -c  "import setuptools; execfile(\'setup.py\')" bdist_egg')
+        run('python -c  "import setuptools; __file__=\'setup.py\'; execfile(\'setup.py\')" bdist_egg')
 
     _deploy_dependency_egg(apikey, project_id)
 


### PR DESCRIPTION
If setup.py for a package references `__file__` and there is a c extension (so that it uses the bdist_egg fallback) shub deploy-reqs fails. An example of this is the "regex" package, which gives the error below.

I looked up what pip did and it seems to explicitly set `__file__`, as well as a bunch of other stuff I did not attempt to replicate in this PR: https://github.com/pypa/pip/blob/e41f75b445a32a8d76d0dc7b5f00e8630b48c397/pip/req/req_install.py#L430

```
Building egg in: /tmp/eggsOt6ieD/eggs/regex-2015.07.19
usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
   or: setup.py --help [cmd1 cmd2 ...]
   or: setup.py --help-commands
   or: setup.py cmd --help

error: invalid command 'bdist_egg'
Couldn't build an egg with vanilla setup.py, trying with setuptools...
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "setup.py", line 9, in <module>
    BASE_DIR = os.path.dirname(os.path.abspath(__file__))
NameError: name '__file__' is not defined
Traceback (most recent call last):
  File "/home/ubuntu/virtualenvs/venv-2.7.9/bin/shub", line 11, in <module>
    sys.exit(cli())
  File "/home/ubuntu/virtualenvs/venv-2.7.9/lib/python2.7/site-packages/click/core.py", line 664, in __call__
    return self.main(*args, **kwargs)
  File "/home/ubuntu/virtualenvs/venv-2.7.9/lib/python2.7/site-packages/click/core.py", line 644, in main
    rv = self.invoke(ctx)
  File "/home/ubuntu/virtualenvs/venv-2.7.9/lib/python2.7/site-packages/click/core.py", line 991, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/ubuntu/virtualenvs/venv-2.7.9/lib/python2.7/site-packages/click/core.py", line 837, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/ubuntu/virtualenvs/venv-2.7.9/lib/python2.7/site-packages/click/core.py", line 464, in invoke
    return callback(*args, **kwargs)
  File "/home/ubuntu/virtualenvs/venv-2.7.9/lib/python2.7/site-packages/shub/deploy_reqs.py", line 18, in cli
    main(project_id, requirements_file)
  File "/home/ubuntu/virtualenvs/venv-2.7.9/lib/python2.7/site-packages/shub/deploy_reqs.py", line 27, in main
    utils.build_and_deploy_eggs(project_id, apikey)
  File "/home/ubuntu/virtualenvs/venv-2.7.9/lib/python2.7/site-packages/shub/utils.py", line 105, in build_and_deploy_eggs
    build_and_deploy_egg(project_id, apikey)
  File "/home/ubuntu/virtualenvs/venv-2.7.9/lib/python2.7/site-packages/shub/utils.py", line 130, in build_and_deploy_egg
    run('python -c  "import setuptools; execfile(\'setup.py\')" bdist_egg')
  File "/home/ubuntu/virtualenvs/venv-2.7.9/lib/python2.7/site-packages/shub/utils.py", line 81, in run
    output = subprocess.check_output(cmd, shell=True)
  File "/home/ubuntu/.pyenv/versions/2.7.9/lib/python2.7/subprocess.py", line 573, in check_output
    raise CalledProcessError(retcode, cmd, output=output)
subprocess.CalledProcessError: Command 'python -c  "import setuptools; execfile('setup.py')" bdist_egg' returned non-zero exit status 1

Fatal error: local() encountered an error (return code 1) while executing 'shub deploy-reqs 18318 scrapinghub-requirements.txt'
```