### PR TITLE
[MRG+1] Revert "Use the project id in the scrapy.cfg as default for deploy-reqs"

### DIFF
--- a/shub/deploy_reqs.py
+++ b/shub/deploy_reqs.py
@@ -7,25 +7,19 @@ import shutil
 from shub.utils import run, decompress_egg_files
 from shub.click_utils import log
 from shub import utils
-from shub import scrapycfg
 from shub.auth import find_api_key
 
 
 @click.command(help="Build and deploy eggs from requirements.txt")
-@click.option("-p", "--project", help="the project ID to deploy to",
-              type=click.INT)
+@click.argument("project_id", required=True)
 @click.argument("requirements_file", required=True)
-def cli(project, requirements_file):
+def cli(project_id, requirements_file):
     """Just a wrapper around the deploy_egg module"""
-    main(project, requirements_file)
+    main(project_id, requirements_file)
 
 
 def main(project_id, requirements_file):
-    target = scrapycfg.get_target('default')
-    project_id = scrapycfg.get_project(target, project_id)
     apikey = find_api_key()
-    log('Deploying requirements to project "%s"' % project_id)
-
     requirements_full_path = os.path.abspath(requirements_file)
     eggs_tmp_dir = _mk_and_cd_eggs_tmpdir()
     _download_egg_files(eggs_tmp_dir, requirements_full_path)
@@ -49,7 +43,7 @@ def _download_egg_files(eggs_dir, requirements_file):
         pip_cmd = ("pip install -d {eggs_dir} -r {requirements_file}"
                    " --src {editable_src_dir} --no-deps --no-use-wheel")
         log(run(pip_cmd.format(eggs_dir=eggs_dir,
-                               editable_src_dir=editable_src_dir,
-                               requirements_file=requirements_file)))
+                                 editable_src_dir=editable_src_dir,
+                                 requirements_file=requirements_file)))
     finally:
         shutil.rmtree(editable_src_dir, ignore_errors=True)

--- a/tests/test_deploy_reqs.py
+++ b/tests/test_deploy_reqs.py
@@ -6,44 +6,23 @@ from __future__ import print_function
 import unittest
 import os
 import tempfile
-from mock import Mock, patch
-from click.testing import CliRunner
+from mock import Mock
 
 from shub import deploy_reqs
 
 
-@patch('shub.deploy_reqs.utils.build_and_deploy_egg')
 class TestDeployReqs(unittest.TestCase):
-    VALID_APIKEY = '1234'
-
-    def setUp(self):
-        self.runner = CliRunner()
-
-    def cli_run(self, cli, args):
-        return self.runner.invoke(cli, args, env={'SHUB_APIKEY': self.VALID_APIKEY})
-
-    def test_can_decompress_downloaded_packages_and_call_deploy_reqs(self, deploy_egg_mock):
+    def test_can_decompress_downloaded_packages_and_call_deploy_reqs(self):
         # GIVEN
         requirements_file = self._write_tmp_requirements_file()
 
-        with self.runner.isolated_filesystem():
-            # WHEN
-            result = self.cli_run(deploy_reqs.cli, ["-p -1", requirements_file])
+        # WHEN
+        deploy_reqs.utils.build_and_deploy_egg = Mock()
+        project_id = 0
+        deploy_reqs.main(project_id, requirements_file)
 
-            # THEN
-            self.assertEqual(2, deploy_egg_mock.call_count, self.error_for(result))
-
-    def test_uses_project_id_from_scrapy_cfg_per_default(self, deploy_egg_mock):
-        requirements_file = self._write_tmp_requirements_file()
-        with self.runner.isolated_filesystem():
-            # GIVEN
-            self.write_valid_scrapy_cfg()
-
-            # WHEN I don't provide the project id
-            self.cli_run(deploy_reqs.cli, [requirements_file])
-
-            # THEN It uses the project id in the scrapy.cfg file
-            deploy_egg_mock.assert_called_with('-1', self.VALID_APIKEY)
+        # THEN
+        self.assertEqual(2, deploy_reqs.utils.build_and_deploy_egg.call_count)
 
     def _write_tmp_requirements_file(self):
         basepath = 'tests/samples/deploy_reqs_sample_project/'
@@ -56,22 +35,6 @@ class TestDeployReqs(unittest.TestCase):
                 f.write(os.path.abspath(os.path.join(basepath, egg)) + "\n")
 
         return requirements_file
-
-    def write_valid_scrapy_cfg(self):
-
-        valid_scrapy_cfg = """
-[deploy]
-username = API_KEY
-project = -1
-
-[settings]
-default = project.settings
-"""
-        with open('scrapy.cfg', 'w') as f:
-            f.write(valid_scrapy_cfg)
-
-    def error_for(self, result):
-        return '\nOutput: %s.\nException: %s' % (result.output.strip(), repr(result.exception))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Reverts scrapinghub/shub#54

This breaks the backwards compatibility of the command interface and we want to make a release today.