### PR TITLE
[MRG+1] passing apikey as username is suggested by dash

### DIFF
--- a/shub/deploy.py
+++ b/shub/deploy.py
@@ -8,7 +8,7 @@ from subprocess import check_call
 
 import click
 import setuptools  # not used in code but needed in runtime, don't remove!
-_ = setuptools
+_ = setuptools  # NOQA
 
 from scrapy.utils.project import inside_project
 from scrapy.utils.python import retry_on_eintr
@@ -63,7 +63,8 @@ def cli(target, project, version, list_targets, debug, egg, build_egg):
             target = scrapycfg.get_target(target)
             project = scrapycfg.get_project(target, project)
             version = scrapycfg.get_version(target, version)
-            auth = (find_api_key(), '')
+            apikey = target.get('username') or find_api_key()
+            auth = (apikey, '')
 
             if egg:
                 log("Using egg: %s" % egg)


### PR DESCRIPTION
For example in projects like https://staging.scrapinghub.com/p/53/deploy/

```
# Project: dangra-sandbox
[deploy]
url = https://staging.scrapinghub.com/api/scrapyd/
username = YOUR_LONG_APIKEY_IS_HERE
password =
project = 53
```

Having a way to pass the apikey in the same section than project and endpoint is quite convenient for Dash development, for i.e.:

```
[deploy:vagrant]
url = http://vagrant.host.name/api/scrapyd
username = DEVELOPER_APIKEY
project = 1
```