### PR TITLE
added schedule and items commands

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ six
 # cryptography must be 1.0 because travis is still using pypy2.5
 # see https://github.com/travis-ci/travis-ci/issues/4756
 cryptography==1.0
+hubstorage

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ six
 # see https://github.com/travis-ci/travis-ci/issues/4756
 cryptography==1.0
 hubstorage
+scrapinghub

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     },
     include_package_data=True,
     zip_safe=False,
-    install_requires=['click', 'requests', 'six', 'hubstorage'],
+    install_requires=['click', 'requests', 'six', 'hubstorage', 'scrapinghub'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     },
     include_package_data=True,
     zip_safe=False,
-    install_requires=['click', 'requests', 'six'],
+    install_requires=['click', 'requests', 'six', 'hubstorage'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',

--- a/shub/items.py
+++ b/shub/items.py
@@ -1,0 +1,25 @@
+import click
+from click import ClickException
+from hubstorage import HubstorageClient
+from shub.utils import find_api_key, is_valid_jobid
+
+
+@click.command(help='Get items of a given job on Scrapy Cloud')
+@click.pass_context
+@click.argument('job_id')
+def cli(context, job_id):
+    if not is_valid_jobid(job_id):
+        raise ClickException('Invalid Job ID. Job ID must be: projectid/spiderid/jobid')
+    apikey = find_api_key()
+    if not apikey:
+        raise ClickException('Scrapinghub API key not found: please, run \'scrapy login\' first')
+    for item in fetch_items_for_job(apikey, job_id):
+        click.echo(item)
+
+
+def fetch_items_for_job(apikey, job_id):
+    hc = HubstorageClient(auth=apikey)
+    job = hc.get_job(job_id)
+    if not job.metadata:
+        raise ClickException('The job {} doesn\'t exist'.format(job_id))
+    return job.items.iter_values()

--- a/shub/items.py
+++ b/shub/items.py
@@ -9,7 +9,7 @@ from shub.utils import find_api_key, is_valid_jobid
 @click.argument('job_id')
 def cli(context, job_id):
     if not is_valid_jobid(job_id):
-        raise ClickException('Invalid Job ID. Job ID must be: projectid/spiderid/jobid')
+        raise ClickException('Invalid job ID. Job ID must be: projectid/spiderid/jobid')
     apikey = find_api_key()
     if not apikey:
         raise ClickException('Scrapinghub API key not found: please, run \'scrapy login\' first')

--- a/shub/schedule.py
+++ b/shub/schedule.py
@@ -1,0 +1,45 @@
+from ConfigParser import NoSectionError, NoOptionError
+import click
+from click import ClickException
+from hubstorage import HubstorageClient
+from shub import scrapycfg
+from shub.utils import find_api_key
+
+
+@click.command(help='Schedule a spider to run on Scrapy Cloud')
+@click.pass_context
+@click.argument("spider", type=click.STRING)
+@click.option("-p", "--project-id", help="the project ID", type=click.INT)
+@click.option("-a", "--argument", help="argument for the spider", multiple=True)
+def cli(context, project_id, spider, argument):
+    apikey = find_api_key()
+    if not apikey:
+        raise ClickException('Scrapinghub API key not found: please, run \'scrapy login\' first')
+    project_id = project_id or get_project_id_from_config()
+    job_key = schedule_spider(apikey, project_id, spider, argument)
+    click.echo(
+        'Spider {} scheduled: {}\nCheck the spider execution at: '
+        'https://dash.scrapinghub.com/p/{}/job/{}/{}'.format(spider, job_key, *job_key.split('/'))
+    )
+
+
+def schedule_spider(apikey, project_id, spider, arguments=()):
+    hc = HubstorageClient(auth=apikey)
+    project = hc.get_project(project_id)
+    if project.ids.spider(spider) is None:
+        raise ClickException(
+            'Spider \'{}\' doesn\'t exist in project {}'.format(
+                spider, project_id
+            )
+        )
+    job = hc.push_job(projectid=project_id, spidername=spider,
+                      spider_args=dict(x.split('=') for x in arguments))
+    return job.key
+
+
+def get_project_id_from_config():
+    try:
+        conf = scrapycfg.get_config()
+        return conf.get('deploy', 'project')
+    except (NoSectionError, NoOptionError):
+        raise ClickException('missing project id')

--- a/shub/tool.py
+++ b/shub/tool.py
@@ -24,8 +24,8 @@ module_deps = {
     "deploy_reqs": [],
     "logout": [],
     "version": [],
-    "items": ["hubstorage"],
-    "schedule": ["hubstorage"],
+    "items": [],
+    "schedule": [],
 }
 
 for command, modules in module_deps.items():

--- a/shub/tool.py
+++ b/shub/tool.py
@@ -24,6 +24,8 @@ module_deps = {
     "deploy_reqs": [],
     "logout": [],
     "version": [],
+    "items": ["hubstorage"],
+    "schedule": ["hubstorage"],
 }
 
 for command, modules in module_deps.items():

--- a/shub/utils.py
+++ b/shub/utils.py
@@ -3,6 +3,7 @@ import importlib
 import os
 import subprocess
 import sys
+import re
 
 from glob import glob
 from os.path import isdir
@@ -147,6 +148,7 @@ def _deploy_dependency_egg(apikey, project_id):
     success = "Deployed eggs list at: https://dash.scrapinghub.com/p/%s/eggs"
     log(success % project_id)
 
+
 def _last_line_of(s):
     return s.split('\n')[-1]
 
@@ -173,3 +175,7 @@ def _get_egg_info(name):
     egg_path_glob = os.path.join('dist', '%s*' % egg_filename)
     egg_path = glob(egg_path_glob)[0]
     return (egg_filename, egg_path)
+
+
+def is_valid_jobid(jobid):
+    return bool(re.match(r'\d+/\d+/\d+$', jobid))

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -1,0 +1,26 @@
+import mock
+import unittest
+from click import ClickException
+from shub import items
+
+
+class ItemsTest(unittest.TestCase):
+
+    @mock.patch('shub.items.HubstorageClient', spec=True)
+    def test_fetch_items_for_job_with_invalid_job(self, mock_hs):
+        mock_hs.return_value.get_job.return_value.metadata = None
+        self.assertRaisesRegexp(
+            ClickException, 'The job -1/-1/-1 doesn\'t exist',
+            items.fetch_items_for_job, 'FAKE_API_KEY', '-1/-1/-1'
+        )
+
+    @mock.patch('shub.items.HubstorageClient', spec=True)
+    def test_fetch_items_for_job_with_valid_job(self, mock_hs):
+        mock_hs.return_value.get_job.return_value.metadata = 1
+        items.fetch_items_for_job('FAKE_API_KEY', '1/1/1')
+        fake_job = mock_hs.return_value.get_job.return_value
+        self.assertTrue(fake_job.items.iter_values.called)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,0 +1,27 @@
+import mock
+import unittest
+from click import ClickException
+from shub import schedule
+
+
+class ScheduleTest(unittest.TestCase):
+
+    @mock.patch('shub.schedule.HubstorageClient', spec=True)
+    def test_schedule_spider_calls_push_job(self, mock_hs):
+        mock_hs.return_value.get_project.return_value.ids.spider.return_value = 1
+        mock_hs.return_value.push_job.return_value.key = mock.sentinel.jobkey
+        jobkey = schedule.schedule_spider('FAKE_API_KEY', 1, 'fake_spider')
+        self.assertEqual(jobkey, mock.sentinel.jobkey)
+
+    @mock.patch('shub.schedule.HubstorageClient', spec=True)
+    def test_schedule_spider_unknown_spider(self, mock_hs):
+        mock_hs.return_value.get_project.return_value.ids.spider.return_value = None
+
+        self.assertRaisesRegexp(
+            ClickException, "Spider \'\w+\' doesn\'t exist in project \d+",
+            schedule.schedule_spider, 'FAKE_API_KEY', 1, 'fake_spider'
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -3,6 +3,7 @@ import unittest
 from click import ClickException
 from click.testing import CliRunner
 from shub import schedule
+from scrapinghub import APIError
 
 
 class ScheduleTest(unittest.TestCase):
@@ -26,23 +27,18 @@ class ScheduleTest(unittest.TestCase):
 
     @mock.patch('shub.schedule.Connection', spec=True)
     def test_schedule_spider_raises_click_exception_with_invalid_spider(self, mock_conn):
-        mock_conn.return_value.project_ids.return_value = [1]
         mock_conn.return_value.__getitem__.return_value.id = 1
-        mock_conn.return_value.__getitem__.return_value.spiders.return_value = []
-        self.assertRaisesRegexp(
-            ClickException, "spider fake_spider doesn\'t exist in project 1",
-            schedule.schedule_spider, 'FAKE_API_KEY', 1, 'fake_spider'
+        mock_conn.return_value.__getitem__.return_value.schedule.side_effect = APIError('')
+        self.assertRaises(
+            ClickException, schedule.schedule_spider, 'FAKE_API_KEY', 1, 'fake_spider'
         )
 
     @mock.patch('shub.schedule.Connection', spec=True)
     def test_schedule_spider_calls_project_schedule(self, mock_conn):
         mock_conn = mock_conn.return_value
-        mock_conn.project_ids.return_value = [1]
-        mock_conn.__getitem__.return_value.spiders.return_value = [{'id': 'fake_spider'}]
         mock_conn.__getitem__.return_value.id = 1
-        mock_conn.__getitem__.return_value.schedule.return_value = mock.sentinel.jobkey
-        jobkey = schedule.schedule_spider('FAKE_API_KEY', 1, 'fake_spider')
-        self.assertEqual(jobkey, mock.sentinel.jobkey)
+        schedule.schedule_spider('FAKE_API_KEY', 1, 'fake_spider')
+        self.assertTrue(mock_conn.__getitem__.return_value.schedule.called)
 
 
 if __name__ == '__main__':

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,26 +1,48 @@
 import mock
 import unittest
 from click import ClickException
+from click.testing import CliRunner
 from shub import schedule
 
 
 class ScheduleTest(unittest.TestCase):
 
-    @mock.patch('shub.schedule.HubstorageClient', spec=True)
-    def test_schedule_spider_calls_push_job(self, mock_hs):
-        mock_hs.return_value.get_project.return_value.ids.spider.return_value = 1
-        mock_hs.return_value.push_job.return_value.key = mock.sentinel.jobkey
-        jobkey = schedule.schedule_spider('FAKE_API_KEY', 1, 'fake_spider')
-        self.assertEqual(jobkey, mock.sentinel.jobkey)
+    def setUp(self):
+        self.runner = CliRunner()
 
-    @mock.patch('shub.schedule.HubstorageClient', spec=True)
-    def test_schedule_spider_unknown_spider(self, mock_hs):
-        mock_hs.return_value.get_project.return_value.ids.spider.return_value = None
+    @mock.patch('shub.schedule.find_api_key', autospec=True)
+    def test_apikey_is_validated(self, mock_find_apikey):
+        mock_find_apikey.return_value = None
+        output = self.runner.invoke(schedule.cli, ['fake_spider', '-p', 1]).output
+        err = 'Unexpected output: %s' % output
+        self.assertTrue('key not found' in output, err)
 
+    @mock.patch('shub.schedule.find_api_key', autospec=True)
+    @mock.patch('shub.schedule.schedule_spider', autospec=True)
+    def test_schedules_job_if_input_is_ok(self, mock_find_apikey, mock_schedule_spider):
+        mock_find_apikey.return_value = 1
+        self.runner.invoke(schedule.cli, ['fake_spider', '-p', 1])
+        self.assertTrue(mock_schedule_spider.called)
+
+    @mock.patch('shub.schedule.Connection', spec=True)
+    def test_schedule_spider_raises_click_exception_with_invalid_spider(self, mock_conn):
+        mock_conn.return_value.project_ids.return_value = [1]
+        mock_conn.return_value.__getitem__.return_value.id = 1
+        mock_conn.return_value.__getitem__.return_value.spiders.return_value = []
         self.assertRaisesRegexp(
-            ClickException, "Spider \'\w+\' doesn\'t exist in project \d+",
+            ClickException, "spider fake_spider doesn\'t exist in project 1",
             schedule.schedule_spider, 'FAKE_API_KEY', 1, 'fake_spider'
         )
+
+    @mock.patch('shub.schedule.Connection', spec=True)
+    def test_schedule_spider_calls_project_schedule(self, mock_conn):
+        mock_conn = mock_conn.return_value
+        mock_conn.project_ids.return_value = [1]
+        mock_conn.__getitem__.return_value.spiders.return_value = [{'id': 'fake_spider'}]
+        mock_conn.__getitem__.return_value.id = 1
+        mock_conn.__getitem__.return_value.schedule.return_value = mock.sentinel.jobkey
+        jobkey = schedule.schedule_spider('FAKE_API_KEY', 1, 'fake_spider')
+        self.assertEqual(jobkey, mock.sentinel.jobkey)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The `shub schedule` and `shub items` commands were added. Here is how they work:

#### shub schedule
Schedule a spider for execution. Example:
```
$ #scheduling 'my_spider' for project 26736
$ shub schedule my_spider -p 26736

$ #scheduling 'my_spyder' for project defined in scrapy.cfg
$ shub schedule my_spider

$ #passing arguments to the spider
$ shub schedule my_spider -p 26736 -a arg1=foo arg2=bar
```

#### shub items
Fetch items from a given job. Example:
```
$ #getting the items scraped by job 26736/2/71
$ shub items 26736/2/71
```