### PR TITLE
Enabling container-based builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python: 2.7
+sudo: false
 env:
 - TOXENV=py27
 install:


### PR DESCRIPTION
Idea is to use the container-based infrastructure, to avoid the builds to take so long to start.

See: https://docs.travis-ci.com/user/ci-environment/