### PR TITLE
remove dependecy check per command

### DIFF
--- a/shub/tool.py
+++ b/shub/tool.py
@@ -1,41 +1,27 @@
 import click, importlib
 import shub
-from shub.utils import missing_modules
-
-def missingmod_cmd(modules):
-    modlist = ", ".join(modules)
-    @click.command(help="*DISABLED* - requires %s" % modlist)
-    @click.pass_context
-    def cmd(ctx):
-        click.echo("Error: '%s' command requires %s" % (ctx.info_name, modlist))
-        ctx.exit(1)
-    return cmd
 
 @click.group(help="Scrapinghub command-line client")
 @click.version_option(shub.__version__)
 def cli():
     pass
 
-module_deps = {
-    "deploy": ["setuptools"],
-    "login": [],
-    "deploy_egg": [],
-    "fetch_eggs": [],
-    "deploy_reqs": [],
-    "logout": [],
-    "version": [],
-    "items": [],
-    "schedule": [],
-    "log": [],
-    "requests": [],
-}
+commands = [
+    "deploy",
+    "login",
+    "deploy_egg",
+    "fetch_eggs",
+    "deploy_reqs",
+    "logout",
+    "version",
+    "items",
+    "schedule",
+    "log",
+    "requests",
+]
 
-for command, modules in module_deps.items():
-    m = missing_modules(*modules)
-    if m:
-        cli.add_command(missingmod_cmd(m), command)
-    else:
-        module_path = "shub." + command
-        command_module = importlib.import_module(module_path)
-        command_name = command.replace('_', '-') # easier to type
-        cli.add_command(command_module.cli, command_name)
+for command in commands:
+    module_path = "shub." + command
+    command_module = importlib.import_module(module_path)
+    command_name = command.replace('_', '-') # easier to type
+    cli.add_command(command_module.cli, command_name)

--- a/shub/utils.py
+++ b/shub/utils.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals, absolute_import
-import importlib
 import os
 import subprocess
 import sys
@@ -21,17 +20,6 @@ from shub.exceptions import AuthException
 SCRAPY_CFG_FILE = os.path.expanduser("~/.scrapy.cfg")
 FALLBACK_ENCODING = 'utf-8'
 STDOUT_ENCODING = sys.stdout.encoding or FALLBACK_ENCODING
-
-
-def missing_modules(*modules):
-    """Receives a list of module names and returns those which are missing"""
-    missing = []
-    for module_name in modules:
-        try:
-            importlib.import_module(module_name)
-        except ImportError:
-            missing.append(module_name)
-    return missing
 
 
 def make_deploy_request(url, data, files, auth):


### PR DESCRIPTION
This is no longer needed because:

1. shub no longer depends on Scrapy (the big/inconvenient dependency that motivated this mechanism in the first place)
2. shub will be frozen and distributed in a binary form