### PR TITLE
Make sure API keys are always returned as string

### DIFF
--- a/shub/config.py
+++ b/shub/config.py
@@ -82,7 +82,7 @@ class ShubConfig(object):
         """Return API key for endpoint associated with given target"""
         endpoint = self._parse_project(target)[1]
         try:
-            return self.apikeys[endpoint]
+            return str(self.apikeys[endpoint])
         except KeyError:
             if not required:
                 return None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -153,6 +153,9 @@ class ShubConfigTest(unittest.TestCase):
             self.conf.get_apikey('externalproj', required=False),
             None,
         )
+        # API keys should always be strings, even if they contain only digits
+        self.conf.apikeys['default'] = 123
+        self.assertEqual(self.conf.get_apikey('shproj'), '123')
 
     @mock.patch('shub.config.pwd_git_version', return_value='ver_GIT')
     @mock.patch('shub.config.pwd_hg_version', return_value='ver_HG')


### PR DESCRIPTION
Without this, API keys that (by chance) contain only digits will be parsed as integers by PyYAML and run into trouble [here](https://github.com/scrapinghub/python-scrapinghub/blob/master/scrapinghub.py#L64)