### PR TITLE
Allow passing settings via schedule

### DIFF
--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 
 import mock
@@ -22,33 +23,51 @@ class ScheduleTest(unittest.TestCase):
         proj, endpoint, apikey = self.conf.get_target('default')
         # Default
         self.runner.invoke(schedule.cli, ['spider'])
-        mock_schedule.assert_called_with(proj, endpoint, apikey, 'spider', ())
+        mock_schedule.assert_called_with(
+            proj, endpoint, apikey, 'spider', (), ())
         # Other project
         self.runner.invoke(schedule.cli, ['123/spider'])
-        mock_schedule.assert_called_with(123, endpoint, apikey, 'spider', ())
+        mock_schedule.assert_called_with(
+            123, endpoint, apikey, 'spider', (), ())
         # Other endpoint
         proj, endpoint, apikey = self.conf.get_target('vagrant')
         self.runner.invoke(schedule.cli, ['vagrant/spider'])
-        mock_schedule.assert_called_with(proj, endpoint, apikey, 'spider', ())
+        mock_schedule.assert_called_with(
+            proj, endpoint, apikey, 'spider', (), ())
         # Other project at other endpoint
         self.runner.invoke(schedule.cli, ['vagrant/456/spider'])
-        mock_schedule.assert_called_with(456, endpoint, apikey, 'spider', ())
+        mock_schedule.assert_called_with(
+            456, endpoint, apikey, 'spider', (), ())
 
-    @mock.patch('shub.schedule.Connection', spec=True)
-    def test_schedule_spider_raises_click_exception_with_invalid_spider(self, mock_conn):
-        mock_conn.return_value.__getitem__.return_value.id = 1
-        mock_conn.return_value.__getitem__.return_value.schedule.side_effect = APIError('')
+    @mock.patch('shub.schedule.Connection', autospec=True)
+    def test_schedule_invalid_spider(self, mock_conn):
+        mock_proj = mock_conn.return_value.__getitem__.return_value
+        mock_proj.schedule.side_effect = APIError('')
         with self.assertRaises(ClickException):
             schedule.schedule_spider(1, 'https://endpoint/api/scrapyd',
                                      'FAKE_API_KEY', 'fake_spider')
 
-    @mock.patch('shub.schedule.Connection', spec=True)
+    @mock.patch('shub.schedule.Connection', autospec=True)
     def test_schedule_spider_calls_project_schedule(self, mock_conn):
-        mock_conn = mock_conn.return_value
-        mock_conn.__getitem__.return_value.id = 1
-        schedule.schedule_spider(1, 'https://endpoint/api/scrapyd', 'FAKE_API_KEY',
-                                 'fake_spider')
-        self.assertTrue(mock_conn.__getitem__.return_value.schedule.called)
+        mock_proj = mock_conn.return_value.__getitem__.return_value
+        schedule.schedule_spider(1, 'https://endpoint/api/scrapyd',
+                                 'FAKE_API_KEY', 'fake_spider')
+        self.assertTrue(mock_proj.schedule.called)
+
+    @mock.patch('shub.schedule.Connection', autospec=True)
+    def test_forwards_args_and_settings(self, mock_conn):
+        mock_proj = mock_conn.return_value.__getitem__.return_value
+        self.runner.invoke(
+            schedule.cli,
+            "testspider -s SETT=99 -a ARG=val1 --set OTHERSETT=10 --argument "
+            "OTHERARG=val2".split(' '),
+        )
+        call_kwargs = mock_proj.schedule.call_args[1]
+        self.assertDictContainsSubset({'ARG': 'val1', 'OTHERARG': 'val2'},
+                                      call_kwargs)
+        # SH API expects settings as json-encoded string named 'job_settings'
+        self.assertEqual({'SETT': '99', 'OTHERSETT': '10'},
+                         json.loads(call_kwargs['job_settings']))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #84.

I chose `--set` as long option name because it matches `scrapy`. It's not really consistent with `--argument` though...