### PR TITLE
Allow equal sign in spider args and job settings

### DIFF
--- a/shub/schedule.py
+++ b/shub/schedule.py
@@ -68,8 +68,8 @@ def schedule_spider(project, endpoint, apikey, spider, arguments=(),
     try:
         return conn[project].schedule(
             spider,
-            job_settings=json.dumps(dict(x.split('=') for x in settings)),
-            **dict(x.split('=') for x in arguments)
+            job_settings=json.dumps(dict(x.split('=', 1) for x in settings)),
+            **dict(x.split('=', 1) for x in arguments)
         )
     except APIError as e:
         raise RemoteErrorException(e.message)

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -59,15 +59,19 @@ class ScheduleTest(unittest.TestCase):
         mock_proj = mock_conn.return_value.__getitem__.return_value
         self.runner.invoke(
             schedule.cli,
-            "testspider -s SETT=99 -a ARG=val1 --set OTHERSETT=10 --argument "
-            "OTHERARG=val2".split(' '),
+            "testspider -s SETT=99 -a ARG=val1 --set SETTWITHEQUAL=10=10 "
+            "--argument ARGWITHEQUAL=val2=val2".split(' '),
         )
         call_kwargs = mock_proj.schedule.call_args[1]
-        self.assertDictContainsSubset({'ARG': 'val1', 'OTHERARG': 'val2'},
-                                      call_kwargs)
+        self.assertDictContainsSubset(
+            {'ARG': 'val1', 'ARGWITHEQUAL': 'val2=val2'},
+            call_kwargs,
+        )
         # SH API expects settings as json-encoded string named 'job_settings'
-        self.assertEqual({'SETT': '99', 'OTHERSETT': '10'},
-                         json.loads(call_kwargs['job_settings']))
+        self.assertEqual(
+            {'SETT': '99', 'SETTWITHEQUAL': '10=10'},
+            json.loads(call_kwargs['job_settings']),
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #100 