### PR TITLE
Migrations for new configuration

### DIFF
--- a/shub/utils.py
+++ b/shub/utils.py
@@ -302,6 +302,20 @@ def get_sources(use_closest=True):
     return sources
 
 
+def get_scrapycfg_targets(cfgfiles=None):
+    cfg = SafeConfigParser()
+    cfg.read(cfgfiles or [])
+    baset = dict(cfg.items('deploy')) if cfg.has_section('deploy') else {}
+    targets = {}
+    targets['default'] = baset
+    for x in cfg.sections():
+        if x.startswith('deploy:'):
+            t = baset.copy()
+            t.update(cfg.items(x))
+            targets[x[7:]] = t
+    return targets
+
+
 def job_live(job, refresh_meta_after=60):
     """
     Check whether job is in 'pending' or 'running' state. If job metadata was

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,6 +4,7 @@ import StringIO
 import tempfile
 import textwrap
 import unittest
+import ruamel.yaml as yaml
 
 import mock
 
@@ -69,6 +70,8 @@ class ShubConfigTest(unittest.TestCase):
         self.assertDictContainsSubset(endpoints, conf.endpoints)
         self.assertEqual(conf.projects, {})
         self.assertEqual(conf.apikeys, {})
+        # Assert no exception raised on empty file
+        conf = self._get_conf_with_yml("")
 
     def test_load_malformed(self):
         # Invalid YAML
@@ -102,6 +105,14 @@ class ShubConfigTest(unittest.TestCase):
         conf.load_file(tmpfilepath)
         shutil.rmtree(tmpdir)
         self.assertEqual({'external': 'ext_endpoint'}, conf.apikeys)
+
+    def test_save(self):
+        tmpdir = tempfile.mkdtemp()
+        tmpfilepath = os.path.join(tmpdir, 'saved_conf.yml')
+        self.conf.save(tmpfilepath)
+        with open(tmpfilepath, 'r') as f:
+            self.assertEqual(yaml.load(f), yaml.load(VALID_YAML_CFG))
+        shutil.rmtree(tmpdir)
 
     def test_get_target(self):
         with self.assertRaises(MissingAuthException):
@@ -193,6 +204,19 @@ LOCAL_SCRAPINGHUB_YML = """
         external: key_ext
 """
 
+GLOBAL_SCRAPY_CFG = textwrap.dedent("""
+    [deploy]
+    url = dotsc_endpoint
+    username = dotsc_key
+
+    [deploy:ext2]
+    url = ext2_endpoint
+    project = 333
+    username = ext2_key
+""")
+
+NETRC = 'machine scrapinghub.com login netrc_key password ""'
+
 
 class LoadShubConfigTest(unittest.TestCase):
 
@@ -200,17 +224,31 @@ class LoadShubConfigTest(unittest.TestCase):
         self.tmpdir = tempfile.mkdtemp()
         self.globalpath = os.path.join(self.tmpdir, '.scrapinghub.yml')
         self.localpath = os.path.join(self.tmpdir, 'scrapinghub.yml')
+        self.globalscrapycfgpath = os.path.join(self.tmpdir, '.scrapy.cfg')
+        self.localscrapycfgpath = os.path.join(self.tmpdir, 'scrapy.cfg')
+        self.netrcpath = os.path.join(self.tmpdir, '.netrc')
         with open(self.globalpath, 'w') as f:
             f.write(VALID_YAML_CFG)
         with open(self.localpath, 'w') as f:
             f.write(LOCAL_SCRAPINGHUB_YML)
+        with open(self.globalscrapycfgpath, 'w') as f:
+            f.write(GLOBAL_SCRAPY_CFG)
+        with open(self.netrcpath, 'w') as f:
+            f.write(NETRC)
         self._old_dir = os.getcwd()
         os.chdir(self.tmpdir)
 
         patcher_gsyp = mock.patch('shub.config.GLOBAL_SCRAPINGHUB_YML_PATH',
                                   new=self.globalpath)
+        patcher_nrcp = mock.patch('shub.config.NETRC_PATH', new=self.netrcpath)
+        patcher_gs = mock.patch('shub.config.get_sources',
+                                return_value=[self.globalscrapycfgpath])
         self.addCleanup(patcher_gsyp.stop)
+        self.addCleanup(patcher_nrcp.stop)
+        self.addCleanup(patcher_gs.stop)
         patcher_gsyp.start()
+        patcher_nrcp.start()
+        patcher_gs.start()
 
     def tearDown(self):
         os.chdir(self._old_dir)
@@ -224,6 +262,8 @@ class LoadShubConfigTest(unittest.TestCase):
             'local_ext_endpoint',
         )
         self.assertEqual(conf.get_apikey('externalproj'), 'key_ext')
+        with self.assertRaises(BadParameterException):
+            conf.get_project_id('ext2')
 
     def test_local_scrapinghub_yml_in_parent_dir(self):
         subsubdir = os.path.join(self.tmpdir, 'sub/sub')
@@ -254,7 +294,46 @@ class LoadShubConfigTest(unittest.TestCase):
         os.environ.clear()
         os.environ.update(_old_environ)
 
-    def test_fallback_to_scrapy_cfg(self):
+    def test_autocreate_empty_global_scrapinghub_yml(self):
+        os.remove(self.globalpath)
+        os.remove(self.globalscrapycfgpath)
+        os.remove(self.netrcpath)
+        load_shub_config()
+        self.assertTrue(os.path.isfile(self.globalpath))
+        with open(self.globalpath, 'r') as f:
+            self.assertEqual(f.read(), "")
+
+    def test_automigrate_to_global_scrapinghub_yml(self):
+        def _check_conf():
+            conf = load_shub_config()
+            self.assertEqual(
+                conf.get_target('123'),
+                (123, 'dotsc_endpoint', 'netrc_key'),
+            )
+            self.assertEqual(conf.projects['ext2'], 'ext2/333')
+            self.assertEqual(
+                conf.get_target('ext2'),
+                (333, 'ext2_endpoint', 'ext2_key'),
+            )
+        os.remove(self.globalpath)
+        _check_conf()
+        self.assertTrue(os.path.isfile(self.globalpath))
+        os.remove(self.netrcpath)
+        os.remove('.scrapy.cfg')
+        _check_conf()
+
+    def test_automigrate_project_scrapy_cfg(self):
+        def _check_conf():
+            conf = load_shub_config()
+            self.assertEqual(
+                conf.get_target('default'),
+                (222, 'scrapycfg_endpoint', 'key'),
+            )
+            self.assertEqual(
+                conf.get_target('ext2'),
+                (333, 'ext2_endpoint', 'ext2_key'),
+            )
+            self.assertEqual(conf.get_version(), 'ext2_ver')
         scrapycfg = """
             [deploy]
             project = 222
@@ -266,22 +345,19 @@ class LoadShubConfigTest(unittest.TestCase):
             username = ext2_key
             version = ext2_ver
         """
-        with open(os.path.join(self.tmpdir, 'scrapy.cfg'), 'w') as f:
+        with open(self.localscrapycfgpath, 'w') as f:
             f.write(textwrap.dedent(scrapycfg))
+        os.mkdir('project')
+        os.chdir('project')
         conf = load_shub_config()
         with self.assertRaises(BadParameterException):
             conf.get_target('ext2')
         os.remove(self.localpath)
-        conf = load_shub_config()
-        self.assertEqual(
-            conf.get_target('default'),
-            (222, 'scrapycfg_endpoint', 'key'),
-        )
-        self.assertEqual(
-            conf.get_target('ext2'),
-            (333, 'ext2_endpoint', 'ext2_key'),
-        )
-        self.assertEqual(conf.get_version(), 'ext2_ver')
+        # Loaded from scrapy.cfg
+        _check_conf()
+        # Same config should now be loaded from scrapinghub.yml
+        self.assertTrue(os.path.isfile(self.localpath))
+        _check_conf()
 
 
 class ConfigHelpersTest(unittest.TestCase):

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -15,6 +15,7 @@ VALID_KEY = 32 * '1'
 
 
 @patch('shub.config.GLOBAL_SCRAPINGHUB_YML_PATH', new='.scrapinghub.yml')
+@patch('shub.config.NETRC_PATH', new='.netrc')
 class LoginTest(AssertInvokeRaisesMixin, unittest.TestCase):
 
     def setUp(self):

--- a/tests/test_logout.py
+++ b/tests/test_logout.py
@@ -8,6 +8,7 @@ from shub import config, logout
 
 
 @mock.patch('shub.config.GLOBAL_SCRAPINGHUB_YML_PATH', new='.scrapinghub.yml')
+@mock.patch('shub.config.NETRC_PATH', new='.netrc')
 class LogoutTestCase(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Auto-migration for `.netrc` and `.scrapy.cfg` into `.scrapinghub.yml` and for `scrapy.cfg` into `scrapinghub.yml`.

I think this is a solution that minimises the pain we induce users during migration