### PR TITLE
Adding OS X shub builder

### DIFF
--- a/.travis-workarounds.sh
+++ b/.travis-workarounds.sh
@@ -11,5 +11,18 @@ if [[ "${TOXENV}" == "pypy" ]]; then
     sudo rm -rf /usr/local/pypy/bin
 fi
 
+if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+    brew update > /dev/null
+
+    brew install python
+    # Now easy_install and pip are in /usr/local we need to force link
+    brew link --overwrite python
+
+    pip install virtualenv
+
+    # Create a virtualenv
+    virtualenv ~/virtualenv/python2.7
+fi
+
 # Workaround travis-ci/travis-ci#2065
 pip install -U wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,16 @@
 language: python
 python: 2.7
 sudo: false
-env:
-- TOXENV=py27
-- TOXENV=freeze
+matrix:
+  include:
+    - os: osx
+      # Using "generic" because osx in Travis doesn't support python
+      language: generic
 install:
 - "./.travis-workarounds.sh"
+- '[ "$TRAVIS_OS_NAME" != osx ] || source ~/virtualenv/python2.7/bin/activate'
 - pip install -U tox twine wheel
-script: tox
+script: tox -e py27,freeze
 deploy:
   provider: pypi
   distributions: sdist bdist_wheel
@@ -18,4 +21,4 @@ deploy:
     tags: true
     all_branches: true
     repo: scrapinghub/shub
-    condition: "$TOXENV == py27"
+    condition: "$TRAVIS_OS_NAME == linux"


### PR DESCRIPTION
This PR adds OS X in the Travis build to run the build.

Since Travis doesn't support python in OS X I've added python installation with brew in `travis-workarounds.sh` (only when $TRAVIS_OS_NAME is `osx`)

The final build matrix is:
- TOXENV=py27,freeze in linux (Creates linux binary)
- TOXENV=py27,freeze in osx (Creates osx binary)

Link to working build: https://travis-ci.org/scrapinghub/shub/builds/100935289

@dangra @pablohoffman should also add TOXENV=py27 for osx?
