### PR TITLE
Stop using scrapyd as API endpoint

### DIFF
--- a/shub/config.py
+++ b/shub/config.py
@@ -20,7 +20,7 @@ NETRC_PATH = os.path.expanduser('~/_netrc' if os.name == 'nt' else '~/.netrc')
 
 class ShubConfig(object):
 
-    DEFAULT_ENDPOINT = 'https://dash.scrapinghub.com/api/scrapyd/'
+    DEFAULT_ENDPOINT = 'https://dash.scrapinghub.com/api/'
 
     def __init__(self):
         self.projects = {}

--- a/shub/deploy.py
+++ b/shub/deploy.py
@@ -116,7 +116,7 @@ def _url(endpoint, action):
 def _upload_egg(endpoint, eggpath, project, version, auth, verbose, keep_log):
     data = {'project': project, 'version': version}
     files = {'egg': ('project.egg', open(eggpath, 'rb'))}
-    url = _url(endpoint, 'addversion.json')
+    url = _url(endpoint, 'scrapyd/addversion.json')
     click.echo('Deploying to Scrapy Cloud project "%s"' % project)
     return make_deploy_request(url, data, files, auth, verbose, keep_log)
 

--- a/shub/fetch_eggs.py
+++ b/shub/fetch_eggs.py
@@ -30,7 +30,7 @@ def cli(target):
 
 def fetch_eggs(project, endpoint, apikey, destfile):
     auth = (apikey, '')
-    url = urljoin(endpoint, "../eggs/bundle.zip?project=%s" % project)
+    url = urljoin(endpoint, "eggs/bundle.zip?project=%s" % project)
     rsp = requests.get(url=url, auth=auth, stream=True, timeout=300)
 
     _assert_response_is_valid(rsp)

--- a/shub/login.py
+++ b/shub/login.py
@@ -4,7 +4,7 @@ import requests
 from six.moves import input
 from six.moves.urllib.parse import urljoin
 
-from shub.config import load_shub_config, update_config
+from shub.config import load_shub_config, ShubConfig, update_config
 from shub.exceptions import AlreadyLoggedInException
 
 
@@ -53,7 +53,7 @@ def _get_apikey(suggestion='', endpoint=None):
 
 
 def _is_valid_apikey(key, endpoint=None):
-    endpoint = endpoint or "https://dash.scrapinghub.com/api/scrapyd/"
-    validate_api_key_endpoint = urljoin(endpoint, "../v2/users/me")
+    endpoint = endpoint or ShubConfig.DEFAULT_ENDPOINT
+    validate_api_key_endpoint = urljoin(endpoint, "v2/users/me")
     r = requests.get("%s?apikey=%s" % (validate_api_key_endpoint, key))
     return r.status_code == 200

--- a/shub/schedule.py
+++ b/shub/schedule.py
@@ -54,7 +54,7 @@ def cli(spider, argument, set):
     job_key = schedule_spider(project, endpoint, apikey, spider, argument, set)
     watch_url = urljoin(
         endpoint,
-        '../../p/{}/job/{}/{}'.format(*job_key.split('/')),
+        '../p/{}/job/{}/{}'.format(*job_key.split('/')),
     )
     short_key = job_key.split('/', 1)[1] if target == 'default' else job_key
     click.echo("Spider {} scheduled, job ID: {}".format(spider, job_key))
@@ -68,7 +68,7 @@ def cli(spider, argument, set):
 
 def schedule_spider(project, endpoint, apikey, spider, arguments=(),
                     settings=()):
-    conn = Connection(apikey, url=urljoin(endpoint, '..'))
+    conn = Connection(apikey, url=endpoint)
     try:
         return conn[project].schedule(
             spider,

--- a/shub/utils.py
+++ b/shub/utils.py
@@ -173,8 +173,7 @@ def _deploy_dependency_egg(project, endpoint, apikey):
     version = _get_dependency_version(name)
     egg_name, egg_path = _get_egg_info(name)
 
-    # XXX: Should endpoint point to /api/ instead of /api/scrapyd/ by default?
-    url = urljoin(endpoint, '../eggs/add.json')
+    url = urljoin(endpoint, 'eggs/add.json')
     data = {'project': project, 'name': name, 'version': version}
     files = {'egg': (egg_name, open(egg_path, 'rb'))}
     auth = (apikey, '')
@@ -313,6 +312,9 @@ def get_scrapycfg_targets(cfgfiles=None):
             t = baset.copy()
             t.update(cfg.items(x))
             targets[x[7:]] = t
+    for t in targets.values():
+        if t.get('url', "").endswith('scrapyd/'):
+            t['url'] = t['url'][:-8]
     return targets
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -327,20 +327,20 @@ class LoadShubConfigTest(unittest.TestCase):
             conf = load_shub_config()
             self.assertEqual(
                 conf.get_target('default'),
-                (222, 'scrapycfg_endpoint', 'key'),
+                (222, 'scrapycfg_endpoint/', 'key'),
             )
             self.assertEqual(
                 conf.get_target('ext2'),
-                (333, 'ext2_endpoint', 'ext2_key'),
+                (333, 'ext2_endpoint/', 'ext2_key'),
             )
             self.assertEqual(conf.get_version(), 'ext2_ver')
         scrapycfg = """
             [deploy]
             project = 222
-            url = scrapycfg_endpoint
+            url = scrapycfg_endpoint/scrapyd/
 
             [deploy:ext2]
-            url = ext2_endpoint
+            url = ext2_endpoint/scrapyd/
             project = 333
             username = ext2_key
             version = ext2_ver

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -44,13 +44,13 @@ class ScheduleTest(unittest.TestCase):
         mock_proj = mock_conn.return_value.__getitem__.return_value
         mock_proj.schedule.side_effect = APIError('')
         with self.assertRaises(RemoteErrorException):
-            schedule.schedule_spider(1, 'https://endpoint/api/scrapyd',
+            schedule.schedule_spider(1, 'https://endpoint/api/',
                                      'FAKE_API_KEY', 'fake_spider')
 
     @mock.patch('shub.schedule.Connection', autospec=True)
     def test_schedule_spider_calls_project_schedule(self, mock_conn):
         mock_proj = mock_conn.return_value.__getitem__.return_value
-        schedule.schedule_spider(1, 'https://endpoint/api/scrapyd',
+        schedule.schedule_spider(1, 'https://endpoint/api/',
                                  'FAKE_API_KEY', 'fake_spider')
         self.assertTrue(mock_proj.schedule.called)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -28,7 +28,7 @@ def mock_conf(testcase, target=None, attr=None, conf=None):
             'vagrant': 'vagrant/3',
         })
         conf.endpoints.update({
-            'vagrant': 'https://vagrant_ep/api/scrapyd/',
+            'vagrant': 'https://vagrant_ep/api/',
         })
         conf.apikeys.update({
             'default': 32 * '1',


### PR DESCRIPTION
This is purely cosmetic, but `shub` can do more than deploy projects now, and the configured API endpoint should reflect that.

README should be updated when/if this is merged, it's not in here yet b/c it would conflict with #105 