### PR TITLE
Make deploy work on projects that replaced scrapy.cfg for scrapinghub.yml

### DIFF
--- a/shub/deploy.py
+++ b/shub/deploy.py
@@ -122,7 +122,7 @@ def _upload_egg(endpoint, eggpath, project, version, auth, verbose, keep_log):
 
 
 def _build_egg():
-    closest = closest_file('scrapy.cfg')
+    closest = closest_file('scrapy.cfg') or closest_file('scrapinghub.yml')
     os.chdir(os.path.dirname(closest))
     if not os.path.exists('setup.py'):
         settings = get_config().get('settings', 'default')

--- a/shub/utils.py
+++ b/shub/utils.py
@@ -280,7 +280,7 @@ def inside_project():
                           "" % (scrapy_module, exc))
         else:
             return True
-    return bool(closest_file('scrapy.cfg'))
+    return bool(closest_file('scrapy.cfg')) or bool(closest_file('scrapinghub.yml'))
 
 
 def get_config(use_closest=True):


### PR DESCRIPTION
The idea is to allow projects with scrapy.cfg (as long as they have a scrapinghub.yml), right?