### PR TITLE
Fix job_resource_iter test that only fails on OSX

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -126,7 +126,7 @@ class UtilsTest(unittest.TestCase):
 
     @patch('shub.utils.time.sleep')
     def test_job_resource_iter(self, mock_sleep):
-        job = MagicMock()
+        job = MagicMock(spec=['metadata'])
         job.metadata = {'state': 'running'}
 
         def magic_iter(*args, **kwargs):


### PR DESCRIPTION
Should fix [this issue](https://travis-ci.org/scrapinghub/shub/jobs/100832815#L246) with the `job_resource_iter` test that appears in OSX environments