### PR TITLE
Pass windows home env vars to tox to allow os.path.expandvars to work.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ version: '{branch}-{build}'
 
 install:
   - "SET PATH=C:\\Python27;C:\\Python27\\Scripts;%PATH%"
+  - "SET TOX_TESTENV_PASSENV=HOME USERPROFILE HOMEPATH HOMEDRIVE"
   - "pip install -U tox twine wheel"
 
 # Build the binary after tests


### PR DESCRIPTION
Some unit tests fail on windows when try to open `~/.scrapinghub.yml`.

The problem is that `os.path.expanduser` uses `HOME`, `USERPROFILE`, `HOMEPATH` and `HOMEDRIVE` to replace `~`. When tox runs it doesn't pass these variables to the execution and so the expansion doesn't happen.

This only affects windows builds (appveyor.yml)