### PR TITLE
Deploy onboarding + maintenance

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,14 +47,13 @@ This will save your Scrapinghub API key to a file in your home directory
 with your Scrapinghub account.
 
 Next, navigate to a Scrapy project that you wish to upload to Scrapinghub. You
-can deploy it to Scrapy Cloud by providing the Scrapinghub project ID, e.g.::
+can deploy it to Scrapy Cloud via::
 
-    shub deploy 12345
+    shub deploy
 
-Of course, it would be cumbersome if you had to re-enter the project ID
-everytime you wish to deploy. You can define a default project ID, and even
-aliases for multiple project IDs in a YAML configuration file named
-``scrapinghub.yml``, living next to your ``scrapy.cfg``::
+On the first call, this will guide you through a wizard to save your project ID
+into a YAML file named ``scrapinghub.yml``, living next to your ``scrapy.cfg``.
+For advanced uses, you can even define aliases for multiple project IDs there::
 
     # project_directory/scrapinghub.yml
     projects:
@@ -63,6 +62,10 @@ aliases for multiple project IDs in a YAML configuration file named
 
 From anywhere within the project directory tree, you can now deploy via
 ``shub deploy`` (to project 12345) or ``shub deploy prod`` (to project 33333).
+
+You can also directly supply the Scrapinghub project ID, e.g.::
+
+    shub deploy 12345
 
 Next, schedule one of your spiders to run on Scrapy Cloud::
 

--- a/shub/config.py
+++ b/shub/config.py
@@ -81,7 +81,7 @@ class ShubConfig(object):
             self._load_scrapycfg_target(tname, t)
 
     def save(self, path=None):
-        with update_config(path) as yml:
+        with update_yaml_dict(path) as yml:
             yml['projects'] = self.projects
             # Write "123" instead of "'123'"
             for target, project in yml['projects'].iteritems():
@@ -290,7 +290,7 @@ def load_shub_config(load_global=True, load_local=True, load_env=True):
 
 
 @contextlib.contextmanager
-def update_config(conf_path=None):
+def update_yaml_dict(conf_path=None):
     """
     Context manager for updating a YAML file while preserving key ordering and
     comments.

--- a/shub/config.py
+++ b/shub/config.py
@@ -182,7 +182,7 @@ class ShubConfig(object):
 
 MIGRATION_BANNER = """
 -------------------------------------------------------------------------------
-Welcome to shub v1.6!
+Welcome to shub version 2!
 
 This release contains major updates to how shub is configured, as well as
 updates to the commands and shub's look & feel.

--- a/shub/deploy.py
+++ b/shub/deploy.py
@@ -22,7 +22,8 @@ HELP = """
 Deploy the current folder's Scrapy project to Scrapy Cloud.
 
 If you do not supply `target`, the default target from scrapinghub.yml will be
-used. Otherwise, you can specify a numerical project ID:
+used. If you have no scrapinghub.yml, you will be guided through a short wizard
+to create one. You can also specify a numerical project ID:
 
     shub deploy 12345
 

--- a/shub/deploy.py
+++ b/shub/deploy.py
@@ -11,7 +11,7 @@ import setuptools  # not used in code but needed in runtime, don't remove!
 _ = setuptools  # NOQA
 from scrapinghub import Connection, APIError
 
-from shub.config import load_shub_config, update_config
+from shub.config import load_shub_config, update_yaml_dict
 from shub.exceptions import (InvalidAuthException, NotFoundException,
                              RemoteErrorException)
 from shub.utils import (closest_file, get_config, inside_project,
@@ -192,7 +192,7 @@ def _deploy_wizard(conf, target='default'):
     conf.projects[target] = project
     if click.confirm("Save as default", default=True):
         try:
-            with update_config(closest_sh_yml) as conf_yml:
+            with update_yaml_dict(closest_sh_yml) as conf_yml:
                 conf_yml['projects'] = {'default': project}
         except Exception:
             click.echo(

--- a/shub/deploy.py
+++ b/shub/deploy.py
@@ -9,11 +9,13 @@ from subprocess import check_call
 import click
 import setuptools  # not used in code but needed in runtime, don't remove!
 _ = setuptools  # NOQA
+from scrapinghub import Connection, APIError
 
-from shub.utils import closest_file, get_config, inside_project, retry_on_eintr
-from shub.config import load_shub_config
-from shub.exceptions import NotFoundException
-from shub.utils import make_deploy_request
+from shub.config import load_shub_config, update_config
+from shub.exceptions import (InvalidAuthException, NotFoundException,
+                             RemoteErrorException)
+from shub.utils import (closest_file, get_config, inside_project,
+                        make_deploy_request, retry_on_eintr)
 
 
 HELP = """
@@ -58,35 +60,41 @@ setup(
 """
 
 
+def list_targets(ctx, param, value):
+    if not value:
+        return
+    conf = load_shub_config()
+    for name in conf.projects:
+        click.echo(name)
+    ctx.exit()
+
+
 @click.command(help=HELP, short_help=SHORT_HELP)
 @click.argument("target", required=False, default="default")
+@click.option("-l", "--list-targets", help="list available targets",
+              is_flag=True, is_eager=True, expose_value=False,
+              callback=list_targets)
 @click.option("-V", "--version", help="the version to use for deploying")
-@click.option("-l", "--list-targets", help="list available targets", is_flag=True)
-@click.option("-d", "--debug", help="debug mode (do not remove build dir)", is_flag=True)
+@click.option("-d", "--debug", help="debug mode (do not remove build dir)",
+              is_flag=True)
 @click.option("--egg", help="deploy the given egg, instead of building one")
 @click.option("--build-egg", help="only build the given egg, don't deploy it")
-@click.option("-v", "--verbose", help="stream deploy logs to console", is_flag=True)
+@click.option("-v", "--verbose", help="stream deploy logs to console",
+              is_flag=True)
 @click.option("-k", "--keep-log", help="keep the deploy log", is_flag=True)
-def cli(target, version, list_targets, debug, egg, build_egg,
-        verbose, keep_log):
+def cli(target, version, debug, egg, build_egg, verbose, keep_log):
     if not inside_project():
         raise NotFoundException("No Scrapy project found in this location.")
-
-    conf = load_shub_config()
-
-    if list_targets:
-        for name in conf.projects:
-            click.echo(name)
-        return
-
     tmpdir = None
-
     try:
         if build_egg:
             egg, tmpdir = _build_egg()
             click.echo("Writing egg to %s" % build_egg)
             shutil.copyfile(egg, build_egg)
         else:
+            conf = load_shub_config()
+            if target == 'default' and target not in conf.projects:
+                _deploy_wizard(conf)
             project, endpoint, apikey = conf.get_target(target)
             version = version or conf.get_version()
             auth = (apikey, '')
@@ -100,7 +108,8 @@ def cli(target, version, list_targets, debug, egg, build_egg,
 
             _upload_egg(endpoint, egg, project, version, auth,
                         verbose, keep_log)
-            click.echo("Run your spiders at: https://dash.scrapinghub.com/p/%s/" % project)
+            click.echo("Run your spiders at: "
+                       "https://dash.scrapinghub.com/p/%s/" % project)
     finally:
         if tmpdir:
             if debug:
@@ -130,9 +139,11 @@ def _build_egg():
     d = tempfile.mkdtemp(prefix="shub-deploy-")
     o = open(os.path.join(d, "stdout"), "wb")
     e = open(os.path.join(d, "stderr"), "wb")
-    retry_on_eintr(check_call,
-                   [sys.executable, 'setup.py', 'clean', '-a', 'bdist_egg', '-d', d],
-                   stdout=o, stderr=e)
+    retry_on_eintr(
+        check_call,
+        [sys.executable, 'setup.py', 'clean', '-a', 'bdist_egg', '-d', d],
+        stdout=o, stderr=e,
+    )
     o.close()
     e.close()
     egg = glob.glob(os.path.join(d, '*.egg'))[0]
@@ -142,3 +153,54 @@ def _build_egg():
 def _create_default_setup_py(**kwargs):
     with open('setup.py', 'w') as f:
         f.write(_SETUP_PY_TEMPLATE % kwargs)
+
+
+def _has_project_access(project, endpoint, apikey):
+    conn = Connection(apikey, url=endpoint)
+    try:
+        return project in conn.project_ids()
+    except APIError as e:
+        if 'Authentication failed' in e.message:
+            raise InvalidAuthException
+        else:
+            raise RemoteErrorException(e.message)
+
+
+def _deploy_wizard(conf, target='default'):
+    """
+    Ask user for project ID, ensure they have access to that project, and save
+    it to given ``target`` in local ``scrapinghub.yml`` if desired.
+    """
+    closest_scrapycfg = closest_file('scrapy.cfg')
+    # Double-checking to make deploy_wizard() independent of cli()
+    if not closest_scrapycfg:
+        raise NotFoundException("No Scrapy project found in this location.")
+    closest_sh_yml = os.path.join(os.path.dirname(closest_scrapycfg),
+                                'scrapinghub.yml')
+    if os.path.isfile(closest_sh_yml):
+        return
+    # Get default endpoint and API key (meanwhile making sure the user is
+    # logged in)
+    endpoint, apikey = conf.get_endpoint(0), conf.get_apikey(0)
+    project = click.prompt("Target project ID", type=int)
+    if not _has_project_access(project, endpoint, apikey):
+        raise InvalidAuthException(
+            "The account you logged in to has no access to project {}. Please "
+            "double-check the project ID and make sure you logged in to the "
+            "correct acount.".format(project),
+        )
+    conf.projects[target] = project
+    if click.confirm("Save as default", default=True):
+        try:
+            with update_config(closest_sh_yml) as conf_yml:
+                conf_yml['projects'] = {'default': project}
+        except Exception:
+            click.echo(
+                "There was an error while trying to write to scrapinghub.yml. "
+                "Could not save project {} as default.".format(project),
+            )
+        else:
+            click.echo(
+                "Project {} was set as default in scrapinghub.yml. You can "
+                "deploy to it via 'shub deploy' from now on.".format(project),
+            )

--- a/shub/login.py
+++ b/shub/login.py
@@ -4,7 +4,7 @@ import requests
 from six.moves import input
 from six.moves.urllib.parse import urljoin
 
-from shub.config import load_shub_config, ShubConfig, update_config
+from shub.config import load_shub_config, ShubConfig, update_yaml_dict
 from shub.exceptions import AlreadyLoggedInException
 
 
@@ -31,7 +31,7 @@ def cli():
         suggestion=conf.apikeys.get('default'),
         endpoint=global_conf.endpoints.get('default'),
     )
-    with update_config() as conf:
+    with update_yaml_dict() as conf:
         conf.setdefault('apikeys', {})
         conf['apikeys']['default'] = key
 

--- a/shub/logout.py
+++ b/shub/logout.py
@@ -1,6 +1,6 @@
 import click
 
-from shub.config import load_shub_config, update_config
+from shub.config import load_shub_config, update_yaml_dict
 
 
 HELP = """
@@ -18,5 +18,5 @@ def cli():
         click.echo("You are not logged in.")
         return 0
 
-    with update_config() as conf:
+    with update_yaml_dict() as conf:
         del conf['apikeys']['default']

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,7 +11,7 @@ import mock
 from click.testing import CliRunner
 
 from shub.config import (get_target, get_version, load_shub_config, ShubConfig,
-                         update_config)
+                         update_yaml_dict)
 from shub.exceptions import (BadParameterException, BadConfigException,
                              ConfigParseException, MissingAuthException,
                              NotFoundException)
@@ -473,7 +473,7 @@ class LoadShubConfigTest(unittest.TestCase):
 
 class ConfigHelpersTest(unittest.TestCase):
 
-    def test_update_config(self):
+    def test_update_yaml_dict(self):
         YAML_BEFORE = textwrap.dedent("""\
             z_first:
               unrelated: dict
@@ -495,7 +495,7 @@ class ConfigHelpersTest(unittest.TestCase):
         with runner.isolated_filesystem():
             with open('conf.yml', 'w') as f:
                 f.write(YAML_BEFORE)
-            with update_config('conf.yml') as conf:
+            with update_yaml_dict('conf.yml') as conf:
                 conf['a_second']['key1'] = 'newval1'
                 conf['a_second']['key3'] = 'val3'
             with open('conf.yml', 'r') as f:

--- a/tests/test_logout.py
+++ b/tests/test_logout.py
@@ -28,8 +28,8 @@ class LogoutTestCase(unittest.TestCase):
             conf = config.load_shub_config()
             self.assertNotIn('default', conf.apikeys)
 
-    @mock.patch('shub.logout.update_config')
-    def test_fail_on_not_logged_in(self, mock_uc):
+    @mock.patch('shub.logout.update_yaml_dict')
+    def test_fail_on_not_logged_in(self, mock_uyd):
         with self.runner.isolated_filesystem():
             self.runner.invoke(logout.cli)
-            self.assertFalse(mock_uc.called)
+            self.assertFalse(mock_uyd.called)


### PR DESCRIPTION
Add a wizard when users run `shub deploy` but have no `scrapinghub.yml` (and no deploy configuration in `scrapy.cfg`). Users will be prompted for a project ID, access rights to this project will be checked, and users can save it as default to `scrapinghub.yml` if wished.

Also contains some additional maintenance:
* PEP8ify `shub/deploy.py`
* Clean up `shub.deploy.cli()` (outsource `list_targets`)
* Rename `shub.config.update_config()` to `update_yaml_dict()`, since `update_config()` does not work on `ShubConfig` objects
* Update migration banner to reflect next shub version

Resolves #126.