### PR TITLE
Fix standalone deploy and improve behaviour for missing dependencies

### DIFF
--- a/shub/deploy_egg.py
+++ b/shub/deploy_egg.py
@@ -8,7 +8,7 @@ import click
 from shub import utils
 from shub.config import get_target
 from shub.exceptions import BadParameterException, NotFoundException
-from shub.utils import run, decompress_egg_files
+from shub.utils import decompress_egg_files, find_exe, run
 
 
 HELP = """
@@ -86,10 +86,11 @@ def _checkout(repo, git_branch=None):
 
 
 def _fetch_from_pypi(pkg):
+    pip = find_exe('pip')
     tmpdir = tempfile.mkdtemp(prefix='shub-deploy-egg-from-pypi')
-
     click.echo('Fetching %s from pypi' % pkg)
-    pip_cmd = "pip install -d %s %s --no-deps --no-use-wheel" % (tmpdir, pkg)
+    pip_cmd = ("%s install -d %s %s --no-deps --no-use-wheel"
+               "" % (pip, tmpdir, pkg))
     click.echo(run(pip_cmd))
     click.echo('Package fetched successfully')
     os.chdir(tmpdir)

--- a/shub/deploy_reqs.py
+++ b/shub/deploy_reqs.py
@@ -56,9 +56,11 @@ def _download_egg_files(eggs_dir, requirements_file):
 
     click.echo('Downloading eggs...')
     try:
-        pip_cmd = ("pip install -d {eggs_dir} -r {requirements_file}"
+        pip = utils.find_exe('pip')
+        pip_cmd = ("{pip} install -d {eggs_dir} -r {requirements_file}"
                    " --src {editable_src_dir} --no-deps --no-use-wheel")
-        click.echo(run(pip_cmd.format(eggs_dir=eggs_dir,
+        click.echo(run(pip_cmd.format(pip=pip,
+                                      eggs_dir=eggs_dir,
                                       editable_src_dir=editable_src_dir,
                                       requirements_file=requirements_file)))
     finally:

--- a/shub/utils.py
+++ b/shub/utils.py
@@ -80,6 +80,13 @@ def _is_deploy_successful(last_logs):
         pass
 
 
+def find_exe(exe_name):
+    exe = find_executable(exe_name)
+    if not exe:
+        raise NotFoundException("Please install {}".format(exe_name))
+    return exe
+
+
 def get_cmd(cmd):
     with open(os.devnull, 'wb') as null:
         return Popen(cmd, stdout=PIPE, stderr=null)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,6 @@
 
 import os
 import stat
-import textwrap
 import unittest
 
 from mock import MagicMock, patch
@@ -21,6 +20,14 @@ class UtilsTest(unittest.TestCase):
 
     def setUp(self):
         self.runner = CliRunner()
+
+    @patch('shub.utils.find_executable')
+    def test_find_exe(self, mock_fe):
+        mock_fe.return_value = '/usr/bin/python'
+        self.assertEqual(utils.find_exe('python'), '/usr/bin/python')
+        mock_fe.return_value = None
+        with self.assertRaises(NotFoundException):
+            utils.find_exe('python')
 
     @patch('shub.utils.pwd_git_version', return_value='ver_GIT')
     @patch('shub.utils.pwd_hg_version', return_value='ver_HG')


### PR DESCRIPTION
Stand-alone deploy did not work previously as `sys.executable` does not point to the python interpreter when frozen.

Also introduces error messages when `python` or `pip` are not available on the system but are required by a command.