### PR TITLE
use params argument of the requests library

### DIFF
--- a/shub/fetch_eggs.py
+++ b/shub/fetch_eggs.py
@@ -30,8 +30,9 @@ def cli(target):
 
 def fetch_eggs(project, endpoint, apikey, destfile):
     auth = (apikey, '')
-    url = urljoin(endpoint, "eggs/bundle.zip?project=%s" % project)
-    rsp = requests.get(url=url, auth=auth, stream=True, timeout=300)
+    url = urljoin(endpoint, "eggs/bundle.zip")
+    rsp = requests.get(url=url, params={'project': project}, auth=auth,
+                       stream=True, timeout=300)
 
     _assert_response_is_valid(rsp)
 

--- a/shub/login.py
+++ b/shub/login.py
@@ -55,5 +55,5 @@ def _get_apikey(suggestion='', endpoint=None):
 def _is_valid_apikey(key, endpoint=None):
     endpoint = endpoint or ShubConfig.DEFAULT_ENDPOINT
     validate_api_key_endpoint = urljoin(endpoint, "v2/users/me")
-    r = requests.get("%s?apikey=%s" % (validate_api_key_endpoint, key))
+    r = requests.get(validate_api_key_endpoint, params={'apikey': key})
     return r.status_code == 200


### PR DESCRIPTION
When constructing an URL with key/value data, the requests library allows passing
them as a dictionary in the "params" argument.

I think that line is easier to read after this change.

See http://docs.python-requests.org/en/latest/user/quickstart/#passing-parameters-in-urls