### PR TITLE
[WIP] Drop dependency to external commands

### DIFF
--- a/freeze/hooks/runtime-hooks.py
+++ b/freeze/hooks/runtime-hooks.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+os.environ['REQUESTS_CA_BUNDLE'] = os.path.join(
+    sys._MEIPASS, 'requests', 'cacert.pem')

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ click
 requests
 ruamel.yaml
 six
+pip
 
 hubstorage
 scrapinghub

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     },
     include_package_data=True,
     zip_safe=False,
-    install_requires=['click', 'hubstorage', 'requests', 'ruamel.yaml',
+    install_requires=['click', 'hubstorage', 'pip', 'requests', 'ruamel.yaml',
                       'scrapinghub', 'six'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/shub/deploy_egg.py
+++ b/shub/deploy_egg.py
@@ -4,11 +4,12 @@ import tempfile
 from subprocess import Popen, PIPE
 
 import click
+import pip
 
 from shub import utils
 from shub.config import get_target
 from shub.exceptions import BadParameterException, NotFoundException
-from shub.utils import decompress_egg_files, find_exe, run
+from shub.utils import decompress_egg_files, patch_sys_executable
 
 
 HELP = """
@@ -86,12 +87,10 @@ def _checkout(repo, git_branch=None):
 
 
 def _fetch_from_pypi(pkg):
-    pip = find_exe('pip')
     tmpdir = tempfile.mkdtemp(prefix='shub-deploy-egg-from-pypi')
     click.echo('Fetching %s from pypi' % pkg)
-    pip_cmd = ("%s install -d %s %s --no-deps --no-use-wheel"
-               "" % (pip, tmpdir, pkg))
-    click.echo(run(pip_cmd))
+    with patch_sys_executable():
+        pip.main(["install", "-d", tmpdir, pkg, "--no-deps", "--no-use-wheel"])
     click.echo('Package fetched successfully')
     os.chdir(tmpdir)
 

--- a/shub/utils.py
+++ b/shub/utils.py
@@ -94,7 +94,18 @@ def patch_sys_executable():
     """
     if getattr(sys, 'frozen', False):
         orig_exe = sys.executable
-        sys.executable = find_exe('python')
+        try:
+            py_exe = find_exe('python2')
+        except NotFoundException:
+            try:
+                # Will raise NotFoundException if no Python installation found
+                py_exe = find_exe('python')
+                if '2.' not in get_cmd_output([py_exe, '--version']):
+                    raise NotFoundException
+            except NotFoundException:
+                # Explicitly ask for installing 2.7
+                raise NotFoundException("Please install Python 2.7")
+        sys.executable = py_exe
         yield
         sys.executable = orig_exe
     else:

--- a/shub/utils.py
+++ b/shub/utils.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals, absolute_import
+import contextlib
 import datetime
 import errno
 import json
@@ -79,6 +80,25 @@ def _is_deploy_successful(last_logs):
             return True
     except Exception:
         pass
+
+
+@contextlib.contextmanager
+def patch_sys_executable():
+    """
+    Context manager that monkey-patches sys.executable to point to the Python
+    interpreter.
+
+    Some scripts, in particular pip, depend on sys.executable pointing to the
+    Python interpreter. When frozen, however, sys.executable points to the
+    stand-alone file (i.e. the frozen script).
+    """
+    if getattr(sys, 'frozen', False):
+        orig_exe = sys.executable
+        sys.executable = find_exe('python')
+        yield
+        sys.executable = orig_exe
+    else:
+        yield
 
 
 def find_exe(exe_name):

--- a/tests/test_deploy_reqs.py
+++ b/tests/test_deploy_reqs.py
@@ -21,7 +21,7 @@ class TestDeployReqs(unittest.TestCase):
 
     def test_can_decompress_downloaded_packages_and_call_deploy_reqs(self):
         requirements_file = self._write_tmp_requirements_file()
-        with mock.patch('shub.deploy_reqs.utils.build_and_deploy_egg') as m:
+        with mock.patch('shub.utils.build_and_deploy_egg') as m:
             self.runner.invoke(
                 deploy_reqs.cli,
                 ('-r', requirements_file),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -45,13 +45,13 @@ class UtilsTest(unittest.TestCase):
                 f.write("from setuptools import setup\n")
                 f.write("setup(version='1.0')")
             self.assertEqual(utils.pwd_version(), '1.0')
-            long_setup_version = (
+            setup_version = (
                 'Building lxml version 3.4.4.'
                 '\nBuilding without Cython.'
                 '\nUsing build configuration of libxslt 1.1.28'
                 '\n3.4.4'
             )
-            with patch('shub.utils.run', return_value=long_setup_version):
+            with patch('shub.utils.run_python', return_value=setup_version):
                 self.assertEqual(utils.pwd_version(), '3.4.4')
             os.mkdir('subdir')
             os.chdir('subdir')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,7 @@
 
 import os
 import stat
+import sys
 import unittest
 
 from mock import MagicMock, patch
@@ -20,6 +21,44 @@ class UtilsTest(unittest.TestCase):
 
     def setUp(self):
         self.runner = CliRunner()
+
+    @patch('shub.utils.sys.frozen', new=True, create=True)
+    def test_patch_sys_executable(self):
+        def make_mock_find_exe(py2=True, py=True):
+            def find_exe(exe_name):
+                if exe_name == 'python2' and py2:
+                    return '/my/python2'
+                elif exe_name == 'python' and py:
+                    return '/my/python'
+                raise NotFoundException
+            return find_exe
+
+        original_exe = sys.executable
+        with patch('shub.utils.sys.frozen', new=False):
+            with utils.patch_sys_executable():
+                self.assertEqual(sys.executable, original_exe)
+
+        with patch('shub.utils.find_exe', new=make_mock_find_exe()):
+            with utils.patch_sys_executable():
+                self.assertEqual(sys.executable, '/my/python2')
+
+        with patch('shub.utils.find_exe', new=make_mock_find_exe(py2=False)), \
+                patch('shub.utils.get_cmd_output') as mock_gco:
+            mock_gco.return_value = "Python 2.7.11"
+            with utils.patch_sys_executable():
+                self.assertEqual(sys.executable, '/my/python')
+            mock_gco.return_value = "Python 3.5.1"
+            with self.assertRaises(NotFoundException):
+                with utils.patch_sys_executable():
+                    pass
+            # Make sure we properly cleaned up after ourselves
+            self.assertEqual(sys.executable, original_exe)
+
+        with patch('shub.utils.find_exe',
+                   new=make_mock_find_exe(py2=False, py=False)):
+            with self.assertRaises(NotFoundException):
+                with utils.patch_sys_executable():
+                    pass
 
     @patch('shub.utils.find_executable')
     def test_find_exe(self, mock_fe):

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,6 @@ deps =
     -rrequirements.txt
     pyinstaller
 commands =
-    pyinstaller --clean -y -F -n shub --additional-hooks-dir=./freeze/hooks --icon=./freeze/spider-down.ico ./freeze/shubrunner.py
+    pyinstaller --clean -y -F -n shub --additional-hooks-dir=./freeze/hooks --runtime-hook=./freeze/hooks/runtime-hooks.py --icon=./freeze/spider-down.ico ./freeze/shubrunner.py
     {toxinidir}/dist/shub version
 


### PR DESCRIPTION
:boom: **DO NOT MERGE** :boom:

Resolves #129 

Makes `shub` Batteries Included™ by:
- Untarring/unzipping with the Python library instead of calling `unzip` or `tar` (which are seldomly available on Windows)
- Using `pip` as Python module instead of calling it as subprocess

Now if only I knew how to call a separate Python interpreter using PyInstaller...

This is WIP. ~~It works fine when I install `shub` via `pip` but makes problems in the stand-alone versions. In particular, `pip` fails to download any packages when I run it under Windows, for no apparent reason (but has no problems doing it when I run it under Linux using `wine`...).~~

Update: First running `pip.exe install -d tmp requests` (i.e. downloading `requests` with the system-wide `pip` install), then running `shub deploy-egg --from-pypi=requests` (which will read `requests` from the pypi cache) works. I think the problem is related to the frozen version not being able to validate PyPIs SSL certificate.

Update 2: Yup. Fixed it