### PR TITLE
Fix python2 enforcement in patch_sys_executable

### DIFF
--- a/shub/utils.py
+++ b/shub/utils.py
@@ -100,7 +100,9 @@ def patch_sys_executable():
             try:
                 # Will raise NotFoundException if no Python installation found
                 py_exe = find_exe('python')
-                if '2.' not in get_cmd_output([py_exe, '--version']):
+                py_ver = subprocess.check_output([py_exe, '--version'],
+                                                 stderr=subprocess.STDOUT)
+                if '2.' not in py_ver:
                     raise NotFoundException
             except NotFoundException:
                 # Explicitly ask for installing 2.7

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -43,11 +43,11 @@ class UtilsTest(unittest.TestCase):
                 self.assertEqual(sys.executable, '/my/python2')
 
         with patch('shub.utils.find_exe', new=make_mock_find_exe(py2=False)), \
-                patch('shub.utils.get_cmd_output') as mock_gco:
-            mock_gco.return_value = "Python 2.7.11"
+                patch('shub.utils.subprocess.check_output') as mock_co:
+            mock_co.return_value = "Python 2.7.11"
             with utils.patch_sys_executable():
                 self.assertEqual(sys.executable, '/my/python')
-            mock_gco.return_value = "Python 3.5.1"
+            mock_co.return_value = "Python 3.5.1"
             with self.assertRaises(NotFoundException):
                 with utils.patch_sys_executable():
                     pass


### PR DESCRIPTION
`python --version` print version to stderr, not stdout