### PR TITLE
AttributeError when trying: "shub log 1"

### DIFF
--- a/shub/utils.py
+++ b/shub/utils.py
@@ -303,7 +303,7 @@ def get_job_specs(job):
             "project) or target/spiderid/jobid, where target can be either a "
             "project ID or an identifier defined in scrapinghub.yml."
             "".format(job),
-            param='job_id',
+            param_hint='job_id',
         )
     # XXX: Lazy import due to circular dependency
     from shub.config import get_target


### PR DESCRIPTION
When running `shub log 1` I got this traceback:

```python
Traceback (most recent call last):
      File "/home/carlosp420/.virtualenvs/shub/bin/shub", line 9, in <module>
          load_entry_point('shub==1.5.0', 'console_scripts', 'shub')()
        File
      "/home/carlosp420/.virtualenvs/shub/local/lib/python2.7/site-packages/click/core.py",
      line 716, in __call__
          return self.main(*args, **kwargs)
        File
      "/home/carlosp420/.virtualenvs/shub/local/lib/python2.7/site-packages/click/core.py",
      line 706, in main
          e.show()
        File
      "/home/carlosp420/.virtualenvs/shub/local/lib/python2.7/site-packages/click/exceptions.py",
      line 48, in show
          echo('Error: %s' % self.format_message(), file=file, color=color)
        File
      "/home/carlosp420/.virtualenvs/shub/local/lib/python2.7/site-packages/click/exceptions.py",
      line 79, in format_message
          param_hint = self.param.opts or [self.param.human_readable_name]
      AttributeError: 'unicode' object has no attribute 'opts'
```

The click documentation states that the `param` argument of the BadParameter
exception should be "the parameter object that caused the error", while the
argument `param_hint` is "a string that shows up as parameter name".

`shub.utils.get_job_specs` passes the string `"job_id"` to the click Exception. So
it should be passed in the argument `param_hint`.

This change avoids the AttributeError exception. I couldn't add a test case
that triggered the exception.