### PR TITLE
refactored "shub.utils.latest_github_release"

### DIFF
--- a/shub/utils.py
+++ b/shub/utils.py
@@ -450,11 +450,7 @@ def latest_github_release(force_update=False, timeout=1., cache=None):
                                   'last_release.txt')
     today = datetime.date.today().toordinal()
     if not force_update and os.path.isfile(cache):
-        with open(cache, 'r') as f:
-            try:
-                release_data = json.load(f)
-            except Exception:
-                release_data = {}
+        release_data = read_release_data(cache)
         # Check for equality (and not smaller or equal) so we don't get thrown
         # off track if the clock was ever misconfigured and a future date was
         # saved
@@ -473,6 +469,16 @@ def latest_github_release(force_update=False, timeout=1., cache=None):
             json.dump(release_data, f)
     except Exception:
         pass
+    return release_data
+
+
+def read_release_data(cache):
+    """Read release data from file. Returns empty dict if data is missing."""
+    with open(cache, 'r') as f:
+        try:
+            release_data = json.load(f)
+        except ValueError:
+            release_data = {}
     return release_data
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -275,6 +275,17 @@ class UtilsTest(unittest.TestCase):
             with open('./cache.txt', 'r') as f:
                 self.assertEqual(f.read(), 'abc')
 
+    def test_read_release_data(self):
+        with open('./cache.txt', 'w') as f:
+            f.write('abc')
+        self.assertEqual({}, utils.read_release_data('./cache.txt'))
+
+        with open('./cache.txt', 'w') as f:
+            f.write('{"key": "value"}')
+        self.assertEqual(
+                {"key": "value"},
+                utils.read_release_data('./cache.txt'))
+
     @patch('shub.utils.latest_github_release', autospec=True)
     @patch('shub.utils.shub.__version__', new='1.5.0')
     def test_update_available(self, mock_lgr):


### PR DESCRIPTION
This change reduced the complexity of "latest_github_release". I also
added a test for the new function "read_release_data".

Also replaced the generic "Exception" to "ValueError".
