### PR TITLE
Improve pip support

### DIFF
--- a/shub/deploy_egg.py
+++ b/shub/deploy_egg.py
@@ -4,12 +4,11 @@ import tempfile
 from subprocess import Popen, PIPE
 
 import click
-import pip
 
 from shub import utils
 from shub.config import get_target
 from shub.exceptions import BadParameterException, NotFoundException
-from shub.utils import decompress_egg_files, patch_sys_executable
+from shub.utils import decompress_egg_files, download_from_pypi
 
 
 HELP = """
@@ -89,8 +88,7 @@ def _checkout(repo, git_branch=None):
 def _fetch_from_pypi(pkg):
     tmpdir = tempfile.mkdtemp(prefix='shub-deploy-egg-from-pypi')
     click.echo('Fetching %s from pypi' % pkg)
-    with patch_sys_executable():
-        pip.main(["install", "-d", tmpdir, pkg, "--no-deps", "--no-use-wheel"])
+    download_from_pypi(tmpdir, pkg=pkg)
     click.echo('Package fetched successfully')
     os.chdir(tmpdir)
 

--- a/shub/deploy_reqs.py
+++ b/shub/deploy_reqs.py
@@ -3,11 +3,9 @@ import os
 import tempfile
 import shutil
 
-import pip
-
 from shub.config import get_target
 from shub.utils import (build_and_deploy_eggs, decompress_egg_files,
-                        patch_sys_executable)
+                        download_from_pypi)
 
 
 HELP = """
@@ -58,11 +56,7 @@ def _download_egg_files(eggs_dir, requirements_file):
 
     click.echo('Downloading eggs...')
     try:
-        with patch_sys_executable():
-            pip.main(
-                ["install", "-d", eggs_dir, "-r", requirements_file, "--src",
-                 editable_src_dir, "--no-deps", "--no-use-wheel"]
-                )
-
+        download_from_pypi(eggs_dir, reqfile=requirements_file,
+                           extra_args=["--src", editable_src_dir])
     finally:
         shutil.rmtree(editable_src_dir, ignore_errors=True)


### PR DESCRIPTION
Unify downloading PyPI packages and improve support for different pip versions. This should work all the way back to pip 1.0 now (which is the version in Ubuntu Precise). Probably earlier, but that's as far as I tested.

`pip install -d` was deprecated in 8.0.0 in favour of `pip download`. The `-d` flag has stayed to configure the download destination.

`--no-use-wheel` was introduced in pip 1.4.0 (and was default before that), deprecated in pip 7.0.0 in favour of `--no-binary=:all:`, and completely removed in 8.0.0.