### PR TITLE
Extend poll timeout in freeze test

### DIFF
--- a/freeze/tests/run.py
+++ b/freeze/tests/run.py
@@ -52,7 +52,7 @@ def test_deploy_without_project():
 
 def test_deploy_default_project(apipipe, scrapyproject):
     p = shub('deploy')
-    assert apipipe.poll(5)
+    assert apipipe.poll(15)
     req = apipipe.recv()
     assert req['path'] == '/api/scrapyd/addversion.json'
     apipipe.send((200, None, {'status': 'ok'}))


### PR DESCRIPTION
This test fails randomly because of timeout on AppVeyor. E.g. [here](https://ci.appveyor.com/project/scrapinghub/shub/build/master-84) but not in [this run with identical code](https://ci.appveyor.com/project/scrapinghub/shub/build/master-83)