### PR TITLE
Add support for job URLs as job spec

### DIFF
--- a/shub/items.py
+++ b/shub/items.py
@@ -12,6 +12,10 @@ the job ID, separated by forward slashes, e.g.:
 
     shub items 12345/2/15
 
+You can also provide the Dash job URL instead:
+
+    shub items https://dash.scrapinghub.com/p/12345/job/2/15
+
 You can omit the project ID if you have a default target defined in your
 scrapinghub.yml:
 

--- a/shub/log.py
+++ b/shub/log.py
@@ -14,6 +14,10 @@ the job ID, separated by forward slashes, e.g.:
 
     shub log 12345/2/15
 
+You can also provide the Dash job URL instead:
+
+    shub log https://dash.scrapinghub.com/p/12345/job/2/15
+
 You can omit the project ID if you have a default target defined in your
 scrapinghub.yml:
 

--- a/shub/requests.py
+++ b/shub/requests.py
@@ -12,6 +12,10 @@ the job ID, separated by forward slashes, e.g.:
 
     shub requests 12345/2/15
 
+You can also provide the Dash job URL instead:
+
+    shub requests https://dash.scrapinghub.com/p/12345/job/2/15
+
 You can omit the project ID if you have a default target defined in your
 scrapinghub.yml:
 

--- a/shub/utils.py
+++ b/shub/utils.py
@@ -311,8 +311,13 @@ def get_job_specs(job):
     * 1/1 -> 10/1/1
     * 2/2/2 -> 2/2/2
     * external/2/2 -> 20/2/2
+
+    It also accepts job URLs from Scrapy Cloud Dashboard.
     """
     match = re.match(r'^((\w+)/)?(\d+/\d+)$', job)
+    if not match:
+        dash_job_url_re = r'^https?://[^/]+/p/((\d+)/)job/(\d+/\d+).*'
+        match = re.match(dash_job_url_re, job)
     if not match:
         raise BadParameterException(
             "Job ID {} is invalid. Format should be spiderid/jobid (inside a "

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -113,6 +113,11 @@ class UtilsTest(unittest.TestCase):
         _test_specs('default/2/3', '1/2/3', 'default')
         _test_specs('prod/2/3', '2/2/3', 'default')
         _test_specs('vagrant/2/3', '3/2/3', 'vagrant')
+        _test_specs(
+            'https://dash.scrapinghub.com/p/7389/job/259/1/#/log/line/0',
+            '7389/259/1',
+            'default',
+        )
 
     def test_get_job_specs_validates_jobid(self):
         invalid_job_ids = ['/1/1', '123', '1/2/a', '1//']


### PR DESCRIPTION
With this PR, you can do:

    shub log -f <PASTE DASH JOB LINK HERE>

Beats typing or editing the link to supply only the job key every time. ;)