### PR TITLE
Don't migrate non-integer project names

### DIFF
--- a/shub/config.py
+++ b/shub/config.py
@@ -221,7 +221,7 @@ def _migrate_to_global_scrapinghub_yml():
 
 
 PROJECT_MIGRATION_OK_BANNER = """
-INFO: Your project configuration has been migrated to scrapinghub.yml.
+INFO: Your deploy configuration has been migrated to scrapinghub.yml.
 shub will no longer read from scrapy.cfg (but Scrapy will, so don't delete it).
 Visit http://doc.scrapinghub.com/shub.html for more information.
 """

--- a/shub/deploy.py
+++ b/shub/deploy.py
@@ -178,8 +178,6 @@ def _deploy_wizard(conf, target='default'):
         raise NotFoundException("No Scrapy project found in this location.")
     closest_sh_yml = os.path.join(os.path.dirname(closest_scrapycfg),
                                   'scrapinghub.yml')
-    if os.path.isfile(closest_sh_yml):
-        return
     # Get default endpoint and API key (meanwhile making sure the user is
     # logged in)
     endpoint, apikey = conf.get_endpoint(0), conf.get_apikey(0)
@@ -194,7 +192,11 @@ def _deploy_wizard(conf, target='default'):
     if click.confirm("Save as default", default=True):
         try:
             with update_yaml_dict(closest_sh_yml) as conf_yml:
-                conf_yml['projects'] = {'default': project}
+                default_entry = {'default': project}
+                if 'projects' in conf_yml:
+                    conf_yml['projects'].update(default_entry)
+                else:
+                    conf_yml['projects'] = default_entry
         except Exception:
             click.echo(
                 "There was an error while trying to write to scrapinghub.yml. "

--- a/shub/utils.py
+++ b/shub/utils.py
@@ -408,9 +408,18 @@ def get_scrapycfg_targets(cfgfiles=None):
             t = baset.copy()
             t.update(cfg.items(x))
             targets[x[7:]] = t
-    for t in targets.values():
+    for tname, t in targets.items():
+        try:
+            int(t.get('project', 0))
+        except ValueError:
+            # Don't import non-numeric project IDs, and also throw away the
+            # URL and credentials associated with these projects (since the
+            # project ID does not belong to SH, neither do the endpoint or the
+            # auth information)
+            del targets[tname]
         if t.get('url', "").endswith('scrapyd/'):
             t['url'] = t['url'][:-8]
+    targets.setdefault('default', {})
     return targets
 
 

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -3,14 +3,12 @@
 
 import unittest
 import os
-import textwrap
 
 from click.testing import CliRunner
 from mock import patch
 
 from shub import deploy
-from shub.exceptions import (BadParameterException, InvalidAuthException,
-                             NotFoundException)
+from shub.exceptions import InvalidAuthException, NotFoundException
 
 from .utils import AssertInvokeRaisesMixin, mock_conf
 
@@ -95,19 +93,15 @@ class DeployTest(AssertInvokeRaisesMixin, unittest.TestCase):
             self.assertFalse(os.path.exists('scrapinghub.yml'))
             # Create scrapinghub.yml if wished
             del self.conf.projects['default']
-            result = self.runner.invoke(deploy.cli, input='199\n\n')
+            self.runner.invoke(deploy.cli, input='199\n\n')
             self.assertEqual(self.conf.projects['default'], 199)
             self.assertTrue(os.path.exists('scrapinghub.yml'))
-            # Don't prompt when there's any target defined in sh.yml
+            # Also run wizard when there's a scrapinghub.yml but no default
+            # target
             del self.conf.projects['default']
-            with open('scrapinghub.yml', 'w') as f:
-                f.write(textwrap.dedent(
-                    """
-                    projects:
-                      some: 123
-                    """
-                ))
-            self.assertInvokeRaises(BadParameterException, deploy.cli)
+            self.conf.projects['prod'] = 299
+            self.runner.invoke(deploy.cli, input='399\n\n')
+            self.assertEqual(self.conf.projects['default'], 399)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #149 

Also, `shub deploy` will now also call the deploy wizard when there is a `scrapinghub.yml` without default target.