### PR TITLE
Fix PyPI releasing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
 script: tox -e py27,freeze
 
 before_deploy:
-  - tar -czf dist/shub-${TRAVIS_TAG}-${TRAVIS_OS_NAME}-x64.tar.gz -C dist shub
+  - tar -czf dist_bin/shub-${TRAVIS_TAG}-${TRAVIS_OS_NAME}-x64.tar.gz -C dist_bin shub
 
 deploy:
   - provider: pypi
@@ -37,7 +37,7 @@ deploy:
   - provider: releases
     api_key:
       secure: uRviyXNC+lAa/WE5vnCiu4AfG0t+x4+O3noXRbzBPjUn17SfPhC2RUZvIKt+KiO4jLojWBW9CeUVzFiA/3+uZZ9mVejByuXxb1h2IvHhYdoJU2Ui8XEcSQWezNoz9nGpHqPibcA2dea7L1jeJn/M8jX4o0yCaXR/0gKwc6QCImFZqOWpAZPltdWlH7bW/Os2pIeqv3/fiTNLAwOdygJmfZrodJpidIVDwSvm5+SGsGPd1P9vEnAzztKOvTihYRD22hh29eJ9iFts8YMwFN8x/6ioMrqAhcsX8F60cFxpH6fbR+MSCGU2x1ljhZUZfcxSQZ5vDYdmIqjTdAq86gNHYTk5ZOTtZWwnBNTls4Zu0B1ff5sjgtY5TlGoQ/cfrZxYqH0Rm2lypycdcTeGVPV5GqlPmqMtMSkbOTaHDL39JgIfCGH1mP2rXcy/XpQTj1S9D+vd0L3aCBrJtmHeWIKZSvkp4W2iBW92jj1dwf5vYfbX6LdMop6FUs2SQFrO4jFVfxDKlB2Fsbkz1wEX0ZM1L5Vh35jSRJQQ7EmwkNXePwpFwCeDieax7H4HhecrghEoHIRdwH5yko5PgclPJrp31bRmuTz5rE2Jdy4HZFVS8iF7ut0ymcUYI0eU4aeM3RrvTSYQItzd7V4lHZDpHrnRA9kxJd5zWmK0pd1tHKeVZuc=
-    file: dist/shub-${TRAVIS_TAG}-${TRAVIS_OS_NAME}-x64.tar.gz
+    file: dist_bin/shub-${TRAVIS_TAG}-${TRAVIS_OS_NAME}-x64.tar.gz
     skip_cleanup: true
     draft: true
     on:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,17 +19,17 @@ test_script:
   - tox -e py27,freeze
 
 artifacts:
-  - path: dist\shub.exe
-  - path: dist\shub-$(APPVEYOR_REPO_TAG_NAME)-windows-$(PLATFORM).zip
+  - path: dist_bin\shub.exe
+  - path: dist_bin\shub-$(APPVEYOR_REPO_TAG_NAME)-windows-$(PLATFORM).zip
 
 after_test:
-  - 7z a dist\shub-%APPVEYOR_REPO_TAG_NAME%-windows-%PLATFORM%.zip %APPVEYOR_BUILD_FOLDER%\dist\shub.exe
+  - 7z a dist_bin\shub-%APPVEYOR_REPO_TAG_NAME%-windows-%PLATFORM%.zip %APPVEYOR_BUILD_FOLDER%\dist_bin\shub.exe
 
 deploy:
   provider: GitHub
   auth_token:
     secure: mNA38grRkwGjw4zSUX1qA67eE6CRPjk97hRngZf19FuopBwbpPjOALBIlYZWKlDv
-  artifact: dist\shub-$(APPVEYOR_REPO_TAG_NAME)-windows-$(PLATFORM).zip
+  artifact: dist_bin\shub-$(APPVEYOR_REPO_TAG_NAME)-windows-$(PLATFORM).zip
   draft: true
   on:
     appveyor_repo_tag: true

--- a/freeze/tests/run.py
+++ b/freeze/tests/run.py
@@ -9,7 +9,7 @@ from subprocess import Popen, PIPE
 import pytest
 from . import fakeserver
 
-SHUB = abspath(join(dirname(__file__), '../../dist/shub'))
+SHUB = abspath(join(dirname(__file__), '../../dist_bin/shub'))
 
 
 @pytest.fixture(scope='module')

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,6 @@ deps =
 ; Weird setuptools/PyInstaller issue: https://github.com/pyinstaller/pyinstaller/issues/1772
     setuptools==19.2
 commands =
-    pyinstaller --clean -y -F -n shub --additional-hooks-dir=./freeze/hooks --runtime-hook=./freeze/hooks/runtime-hooks.py --icon=./freeze/spider-down.ico ./freeze/shubrunner.py
+    pyinstaller --clean -y -F -n shub --distpath=./dist_bin --additional-hooks-dir=./freeze/hooks --runtime-hook=./freeze/hooks/runtime-hooks.py --icon=./freeze/spider-down.ico ./freeze/shubrunner.py
     py.test {toxinidir}/freeze/tests/run.py
 


### PR DESCRIPTION
Currently, there is [an error while Travis tries to deploy shub to PyPI](https://travis-ci.org/scrapinghub/shub/jobs/108800444#L457). The reason is that `python setup.py sdist` and `PyInstaller` both use the `dist` folder, and whatever script deploys to PyPI doesn't like the `shub` executable in `dist`.

That's why there's no source tarball on PyPI for our newer releases.