### PR TITLE
Correct status of streaming deploy error

### DIFF
--- a/shub/utils.py
+++ b/shub/utils.py
@@ -72,13 +72,18 @@ def write_and_echo_logs(keep_log, last_logs, rsp, verbose):
                 click.echo(line)
             last_logs.append(line)
             log_file.write(line + '\n')
-        echo_short_log_if_deployed(last_logs, log_file, verbose)
+
+        deployed = _is_deploy_successful(last_logs)
+        echo_short_log_if_deployed(deployed, last_logs, log_file, verbose)
         if not log_file.delete:
             click.echo("Deploy log location: %s" % log_file.name)
+        if not deployed:
+            raise RemoteErrorException(
+                "Deploy failed: {}".format(last_logs[-1]))
 
 
-def echo_short_log_if_deployed(last_logs, log_file, verbose):
-    if _is_deploy_successful(last_logs):
+def echo_short_log_if_deployed(deployed, last_logs, log_file, verbose):
+    if deployed:
         if not verbose:
             click.echo(last_logs[-1])
     else:


### PR DESCRIPTION
shub should not tell `Run your spiders at ..` after all the deploy errors when using streaming responses. There's a check already for successful deploys, it's easy to use its result and raise a correct error.

Please, review, and let me know if it can be done in a better way. // cc @dangra 