### PR TITLE
Add support for stack and reqfile configuration

### DIFF
--- a/shub/deploy_egg.py
+++ b/shub/deploy_egg.py
@@ -6,7 +6,7 @@ from subprocess import Popen, PIPE
 import click
 
 from shub import utils
-from shub.config import get_target
+from shub.config import get_target_conf
 from shub.exceptions import BadParameterException, NotFoundException
 from shub.utils import decompress_egg_files, download_from_pypi
 
@@ -47,12 +47,13 @@ def cli(target, from_url=None, git_branch=None, from_pypi=None):
 
 
 def main(target, from_url=None, git_branch=None, from_pypi=None):
-    project, endpoint, apikey = get_target(target)
+    targetconf = get_target_conf(target)
 
     if from_pypi:
         _fetch_from_pypi(from_pypi)
         decompress_egg_files()
-        utils.build_and_deploy_eggs(project, endpoint, apikey)
+        utils.build_and_deploy_eggs(targetconf.project_id, targetconf.endpoint,
+                                    targetconf.apikey)
         return
 
     if from_url:
@@ -62,7 +63,8 @@ def main(target, from_url=None, git_branch=None, from_pypi=None):
         error = "No setup.py -- are you running from a valid Python project?"
         raise NotFoundException(error)
 
-    utils.build_and_deploy_egg(project, endpoint, apikey)
+    utils.build_and_deploy_egg(targetconf.project_id, targetconf.endpoint,
+                               targetconf.apikey)
 
 
 def _checkout(repo, git_branch=None):

--- a/shub/deploy_reqs.py
+++ b/shub/deploy_reqs.py
@@ -3,7 +3,7 @@ import os
 import tempfile
 import shutil
 
-from shub.config import get_target
+from shub.config import get_target_conf
 from shub.utils import (build_and_deploy_eggs, decompress_egg_files,
                         download_from_pypi)
 
@@ -35,12 +35,13 @@ def cli(target, requirements_file):
 
 
 def main(target, requirements_file):
-    project, endpoint, apikey = get_target(target)
+    targetconf = get_target_conf(target)
     requirements_full_path = os.path.abspath(requirements_file)
     eggs_tmp_dir = _mk_and_cd_eggs_tmpdir()
     _download_egg_files(eggs_tmp_dir, requirements_full_path)
     decompress_egg_files()
-    build_and_deploy_eggs(project, endpoint, apikey)
+    build_and_deploy_eggs(targetconf.project_id, targetconf.endpoint,
+                          targetconf.apikey)
 
 
 def _mk_and_cd_eggs_tmpdir():

--- a/shub/fetch_eggs.py
+++ b/shub/fetch_eggs.py
@@ -5,7 +5,7 @@ from six.moves.urllib.parse import urljoin
 import click
 import requests
 
-from shub.config import get_target
+from shub.config import get_target_conf
 from shub.exceptions import InvalidAuthException, RemoteErrorException
 
 
@@ -23,9 +23,10 @@ SHORT_HELP = "Download project eggs from Scrapy Cloud"
 @click.command(help=HELP, short_help=SHORT_HELP)
 @click.argument("target", required=False, default='default')
 def cli(target):
-    project, endpoint, apikey = get_target(target)
-    destfile = 'eggs-%s.zip' % project
-    fetch_eggs(project, endpoint, apikey, destfile)
+    targetconf = get_target_conf(target)
+    destfile = 'eggs-%s.zip' % targetconf.project_id
+    fetch_eggs(targetconf.project_id, targetconf.endpoint, targetconf.apikey,
+               destfile)
 
 
 def fetch_eggs(project, endpoint, apikey, destfile):

--- a/shub/schedule.py
+++ b/shub/schedule.py
@@ -6,7 +6,7 @@ from scrapinghub import Connection, APIError
 from six.moves.urllib.parse import urljoin
 
 from shub.exceptions import RemoteErrorException
-from shub.config import get_target
+from shub.config import get_target_conf
 
 
 HELP = """
@@ -50,10 +50,11 @@ def cli(spider, argument, set):
         target, spider = spider.rsplit('/', 1)
     except ValueError:
         target = 'default'
-    project, endpoint, apikey = get_target(target)
-    job_key = schedule_spider(project, endpoint, apikey, spider, argument, set)
+    targetconf = get_target_conf(target)
+    job_key = schedule_spider(targetconf.project_id, targetconf.endpoint,
+                              targetconf.apikey, spider, argument, set)
     watch_url = urljoin(
-        endpoint,
+        targetconf.endpoint,
         '../p/{}/job/{}/{}'.format(*job_key.split('/')),
     )
     short_key = job_key.split('/', 1)[1] if target == 'default' else job_key

--- a/shub/utils.py
+++ b/shub/utils.py
@@ -339,9 +339,10 @@ def get_job_specs(job):
             param_hint='job_id',
         )
     # XXX: Lazy import due to circular dependency
-    from shub.config import get_target
-    project_id, endpoint, apikey = get_target(match.group(2) or 'default')
-    return "{}/{}".format(project_id, match.group(3)), apikey
+    from shub.config import get_target_conf
+    targetconf = get_target_conf(match.group(2) or 'default')
+    return ("{}/{}".format(targetconf.project_id, match.group(3)),
+            targetconf.apikey)
 
 
 def get_job(job):


### PR DESCRIPTION
Add support for specifying stack and requirements file per-project using the following syntax:

```
# Aliases for stacks
stacks:
  ocr: ocr:v1.2

projects:
  default: 
    id: 123
    # Specifying stack directly
    stack: scrapy:v1.1
  prod: 1  # Will use Dash's default stack
  ads:
    id: 2
    # Resolves to 'ocr:v1.2'
    stack: ocr
```

Also makes sure `shub deploy` will always deploy the same configuration as `shub deploy 123`.

Resolves #171. Closes #172.