### PR TITLE
fix: cli defaults always overrides config values

### DIFF
--- a/shub/deploy_reqs.py
+++ b/shub/deploy_reqs.py
@@ -28,7 +28,7 @@ SHORT_HELP = "Build and deploy eggs from requirements.txt"
 
 @click.command(help=HELP, short_help=SHORT_HELP)
 @click.argument("target", required=False, default="default")
-@click.option("-r", "--requirements-file", default='requirements.txt',
+@click.option("-r", "--requirements-file", default=None,
               type=click.STRING)
 def cli(target, requirements_file):
     main(target, requirements_file)
@@ -36,7 +36,7 @@ def cli(target, requirements_file):
 
 def main(target, requirements_file):
     targetconf = get_target_conf(target)
-    requirements_full_path = os.path.abspath(requirements_file)
+    requirements_full_path = os.path.abspath(requirements_file or targetconf.requirement_files)
     eggs_tmp_dir = _mk_and_cd_eggs_tmpdir()
     _download_egg_files(eggs_tmp_dir, requirements_full_path)
     decompress_egg_files()


### PR DESCRIPTION
Unix conventions for configuration values are, by increasing priority:
- config file(s)
- environment variable(s)
- cli arguments

But cli arguments should, when unspecified should not override lower priority values.
This issue cause us quite a few headaches deploying on scrapinghub, 'cause we used a non-default file name and had a `requirements.txt` file used for a different purpose in the same directory. 