### PR TITLE
tail log output in order to avoid to download the entire log

### DIFF
--- a/shub/log.py
+++ b/shub/log.py
@@ -38,9 +38,11 @@ SHORT_HELP = "Fetch log from Scrapy Cloud"
 
 class LogIterFunc(object):
     def __init__(self, job, tail):
-        logstats = job.logs.stats()
-        lines = logstats['totals']['input_values']
-        lastline = max(lines - tail, -1)
+        lastline = -1
+        if tail is not None:
+            logstats = job.logs.stats()
+            lines = logstats['totals']['input_values']
+            lastline = max(lines - tail, -1)
         if lastline == -1:
             lastline = None
         self._startafter = None if lastline is None else '{}/{}'.format(job.key, lastline)
@@ -57,7 +59,7 @@ class LogIterFunc(object):
 @click.option('-f', '--follow', help='output new log entries as they are '
               'produced', is_flag=True)
 @click.option('-n', '--tail',
-              help='Output last N lines. Default: %(default)s', default=50)
+              help='Output last N lines', type=int)
 def cli(job_id, follow, tail):
     job = get_job(job_id)
     for item in job_resource_iter(job, LogIterFunc(job, tail), follow=follow,

--- a/shub/log.py
+++ b/shub/log.py
@@ -36,13 +36,31 @@ providing the -f flag:
 SHORT_HELP = "Fetch log from Scrapy Cloud"
 
 
+class LogIterFunc(object):
+    def __init__(self, job, tail):
+        logstats = job.logs.stats()
+        lines = logstats['totals']['input_values']
+        lastline = max(lines - tail, -1)
+        if lastline == -1:
+            lastline = None
+        self._startafter = None if lastline is None else '{}/{}'.format(job.key, lastline)
+        self._logs = job.logs
+
+    def __call__(self, startafter=None):
+        startafter = startafter or self._startafter
+        for item in self._logs.iter_values(startafter=startafter):
+            self._startafter = item['_key']
+            yield item
+
 @click.command(help=HELP, short_help=SHORT_HELP)
 @click.argument('job_id')
 @click.option('-f', '--follow', help='output new log entries as they are '
               'produced', is_flag=True)
-def cli(job_id, follow):
+@click.option('-n', '--tail',
+              help='Output last N lines. Default: %(default)s', default=50)
+def cli(job_id, follow, tail):
     job = get_job(job_id)
-    for item in job_resource_iter(job, job.logs.iter_values, follow=follow,
+    for item in job_resource_iter(job, LogIterFunc(job, tail), follow=follow,
                                   key_func=lambda item: item['_key']):
         click.echo(
             "{} {} {}".format(


### PR DESCRIPTION
Note this PR also changes the default behavior (by default will load last 50 lines, not entire log)

Considering the common usage of shub log, I am not sure if we should conserve the default behavior or not.