### PR TITLE
Added: Warnings when an API endpoint is using staging.scrapinghub.com or HTTP

### DIFF
--- a/shub/config.py
+++ b/shub/config.py
@@ -33,6 +33,30 @@ class ShubConfig(object):
         self.stacks = {}
         self.requirements_file = None
 
+    def _check_endpoints(self):
+        """Check the endpoints. Send warnings if necessary."""
+        for endpoint, url in self.endpoints.items():
+            parsed = six.moves.urllib.parse.urlparse(url)
+            if parsed.netloc == 'staging.scrapinghub.com':
+                self.endpoints[endpoint] = six.moves.urllib.parse.urlunparse(
+                    parsed._replace(netloc='app.scrapinghub.com')
+                )
+                click.echo(
+                    'WARNING: Endpoint "%s" is still using %s which has been '
+                    'obsoleted. Shub has had it updated to app.scrapinghub.com '
+                    'for only this time. Please update the configuration '
+                    'ASAP.' % (
+                        endpoint, parsed.netloc,
+                    ),
+                    err=True
+                )
+            if parsed.scheme == 'http':
+                click.echo(
+                    'WARNING: Endpoint "%s" is still using HTTP. '
+                    'Please change it to HTTPS if possible.' % endpoint,
+                    err=True
+                )
+
     def load(self, stream):
         """Load Scrapinghub configuration from stream."""
         try:
@@ -47,6 +71,7 @@ class ShubConfig(object):
         except (yaml.YAMLError, AttributeError):
             # AttributeError: stream is valid YAML but not dictionary-like
             raise ConfigParseException
+        self._check_endpoints()
 
     def load_file(self, filename):
         """Load Scrapinghub configuration from YAML file. """
@@ -87,6 +112,7 @@ class ShubConfig(object):
         del targets['default']
         for tname, t in six.iteritems(targets):
             self._load_scrapycfg_target(tname, t)
+        self._check_endpoints()
 
     def save(self, path=None):
         with update_yaml_dict(path) as yml:

--- a/shub/utils.py
+++ b/shub/utils.py
@@ -56,7 +56,7 @@ def make_deploy_request(url, data, files, auth, verbose, keep_log):
                 error = ('\n---------- REMOTE TRACEBACK ----------\n' + error +
                          '\n---------- END OF REMOTE TRACEBACK ----------')
         except (ValueError, TypeError, KeyError):
-            error = rsp.text
+            error = rsp.text or "Status %d" % rsp.status_code
         msg = "Deploy failed ({}):\n{}".format(rsp.status_code, error)
         raise RemoteErrorException(msg)
     except requests.RequestException as exc:


### PR DESCRIPTION
This PR adds warnings in two cases:
1. When an API endpoint uses `staging.scrapinghub.com`. See also https://scrapinghub.atlassian.net/browse/SC-725
2. When an API endpoint uses HTTP. See also https://scrapinghub.slack.com/archives/security/p1469507392000003

Personally I even wanted to directly "correct" those inappropriate endpoints, since we might assume that users of `shub` are all accessing only Scrapinghub's API (..can we?). But I'm afraid that might look too aggressive.