### PR TITLE
Validate requirements

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -2,6 +2,8 @@ click
 requests
 ruamel.yaml
 six
+requirements-parser
 
 hubstorage
 scrapinghub
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ ruamel.ordereddict==0.4.9  # via ruamel.yaml
 ruamel.yaml==0.10.15
 scrapinghub==1.7.0
 six==1.10.0
+requirements-parser==0.1.0

--- a/shub/deploy.py
+++ b/shub/deploy.py
@@ -8,6 +8,9 @@ from subprocess import check_call
 
 import click
 import setuptools  # not used in code but needed in runtime, don't remove!
+
+from shub.validation import validate_and_dump_for_path
+
 _ = setuptools  # NOQA
 from scrapinghub import Connection, APIError
 
@@ -107,6 +110,16 @@ def cli(target, version, debug, egg, build_egg, verbose, keep_log):
             else:
                 click.echo("Packing version %s" % version)
                 egg, tmpdir = _build_egg()
+
+            if targetconf.requirements_file is not None:
+                a = validate_and_dump_for_path(targetconf.requirements_file,
+                                               click.echo)
+                if a.should_stop:
+                    return
+                elif a.should_ask_to_continue:
+                    r = raw_input('project has warning, continue anyway? [y/N]')
+                    if not r.lower() == 'y':
+                        return
 
             _upload_egg(targetconf.endpoint, egg, targetconf.project_id,
                         version, auth, verbose, keep_log, targetconf.stack,

--- a/shub/validation.py
+++ b/shub/validation.py
@@ -1,0 +1,73 @@
+"""
+Provide validation tools for user input,
+right now deals only with requirements.txt content.
+
+This implements the guidelines from:
+https://support.scrapinghub.com/topics/1970-deploying-dependencies-to-your-scrapinghub-project/
+"""
+from collections import namedtuple
+
+import requirements
+
+ValidationTuple = namedtuple('ValidationTuple', ['line', 'name', 'message'])
+ValidationResult = namedtuple('ValidationResult',
+                              ['is_valid', 'has_warnings', 'errors', 'warnings'])
+
+
+def _is_gitgit(req):
+    """
+    Return whether the requirement specifier is a git+git scheme (not recommended).
+    """
+    from urlparse import urlparse
+
+    uri = req.uri
+
+    if uri is None:
+        return False
+
+    p = urlparse(uri)
+    return p.scheme.lower() == 'git+git'
+
+
+def _has_pinned_version(req):
+    """
+    Return whether the requirement specifier is a pinned version or a URI spec.
+    """
+    try:
+        return (req.uri is not None) or (req.specifier and req.specs[0][0] == '==')
+    except IndexError:
+        # Specs didn't contain ==
+        return False
+
+
+def validate_requirements(reqstr):
+    """
+    Validate a requirements file, given it's content.
+    Return a ValidationResult
+    """
+    reqs = requirements.parse(reqstr)
+
+    errors, warnings = [], []
+
+    for i, req in enumerate(reqs):
+        if req.editable:
+            errors.append(ValidationTuple(i + 1, req.name, 'is editable'))
+        elif _is_gitgit(req):
+            warnings.append(
+                ValidationTuple(i + 1, req.name, 'points to a git repository, use http scheme'))
+        elif not _has_pinned_version(req):
+            warnings.append(ValidationTuple(i + 1, req.name, 'has no version specification'))
+
+    return ValidationResult(is_valid=not errors, has_warnings=len(warnings) > 0,
+                            errors=errors, warnings=warnings)
+
+
+def validate_requirements_path(requirements_path):
+    """
+    Validate a requirements file, given it's path.
+    Return a ValidationResult.
+    """
+    with open(requirements_path, 'r') as f:
+        reqstr = f.read()
+
+    return validate_requirements(reqstr)

--- a/shub/validation.py
+++ b/shub/validation.py
@@ -12,6 +12,8 @@ import requirements
 ValidationTuple = namedtuple('ValidationTuple', ['line', 'name', 'message'])
 ValidationResult = namedtuple('ValidationResult',
                               ['is_valid', 'has_warnings', 'errors', 'warnings'])
+ValidationAttempt = namedtuple('ValidationAttempt',
+                               ['should_stop', 'should_ask_to_continue'])
 
 
 def _is_gitgit(req):
@@ -71,3 +73,29 @@ def validate_requirements_path(requirements_path):
         reqstr = f.read()
 
     return validate_requirements(reqstr)
+
+
+def dump_result(result, dump_fct):
+    """
+    Call the dump_fct for every validation result string.
+    """
+    dump_fct('validating requirements:')
+    for r in result.warnings:
+        dump_fct('WARNING: %s %s (l.%s)' % (r.name, r.message, r.line))
+
+    for r in result.errors:
+        dump_fct('ERROR: %s %s (l.%s)' % (r.name, r.message, r.line))
+
+
+def validate_and_dump_for_path(requirements_path, dump_fct):
+    """
+    Validate a requirements file, given it's path.
+    Dump the errors and warning of the validation using the dump_fct.
+
+    Returns a ValidationAttempt.
+    """
+    result = validate_requirements_path(requirements_path)
+    dump_result(result, dump_fct)
+    return ValidationAttempt(should_stop=not result.is_valid,
+                             should_ask_to_continue=result.has_warnings)
+

--- a/tests/samples/sample_with_requirements/requirements_editable.txt
+++ b/tests/samples/sample_with_requirements/requirements_editable.txt
@@ -1,0 +1,4 @@
+js2xml==0.2.1
+extruct==0.1.0
+-e https://github.com/scrapinghub/extruct/archive/10cbb3a.zip#egg=extruct
+requests==2.6.0

--- a/tests/samples/sample_with_requirements/requirements_no_version.txt
+++ b/tests/samples/sample_with_requirements/requirements_no_version.txt
@@ -1,0 +1,4 @@
+js2xml
+extruct
+requests
+git+git://github.com/scrapinghub/extruct#egg=extruct

--- a/tests/samples/sample_with_requirements/requirements_ok.txt
+++ b/tests/samples/sample_with_requirements/requirements_ok.txt
@@ -1,0 +1,4 @@
+js2xml==0.2.1
+extruct==0.1.0
+requests==2.6.0
+https://github.com/scrapinghub/extruct/archive/10cbb3a.zip#egg=extruct

--- a/tests/samples/sample_with_requirements/requirements_slow.txt
+++ b/tests/samples/sample_with_requirements/requirements_slow.txt
@@ -1,0 +1,4 @@
+js2xml==0.2.1
+extruct==0.1.0
+requests==2.6.0
+git+git://github.com/scrapinghub/extruct@10cbb3a#egg=extruct

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,26 @@
+import unittest
+
+from shub.validation import validate_requirements_path
+
+
+def get_sample_requirement(suffix):
+    p = 'tests/samples/sample_with_requirements/requirements_%s.txt' % suffix
+    return p
+
+
+class ValidationTest(unittest.TestCase):
+    def test_basic_requirements_is_ok(self):
+        v = validate_requirements_path(get_sample_requirement('ok'))
+        assert v.is_valid and not v.has_warnings
+
+    def test_no_version_has_warnings(self):
+        v = validate_requirements_path(get_sample_requirement('no_version'))
+        assert v.is_valid and v.has_warnings
+
+    def test_slow_has_warnings(self):
+        v = validate_requirements_path(get_sample_requirement('slow'))
+        assert v.is_valid and v.has_warnings
+
+    def test_editable_is_not_valid(self):
+        v = validate_requirements_path(get_sample_requirement('editable'))
+        assert not v.is_valid


### PR DESCRIPTION
This is a proposal to validate requirements.

When you setup dependencies for your SC2.0 project, there are a bunch of edge cases to consider.
This PR adds a validation step for the requirements.txt with good practices described in:
https://support.scrapinghub.com/topics/1970-deploying-dependencies-to-your-scrapinghub-project/

When you `shub deploy`, requirements are validated:

```
› shub deploy                                                                                     ☺
Packing version 1.0
validating requirements:
WARNING: requests has no version specification (l.1)
WARNING: js2xml has no version specification (l.2)
WARNING: extruct points to a git repository, use http scheme (l.5)
ERROR: packagex is editable (l.6)
```

In case of errors, the command stops. In case of warnings, an input appears:
```
project has warning, continue anyway? [y/N]
```

TODOs:
- [ ] exit with an error code
- [ ] link to the relevant documentation on warnings/errors (the support page is fine?)
- [ ] add test of the integration in the endpoints (only validation module is tested)
- [ ] check that integration is correct and enough (only deploy?)
