### PR TITLE
Allow specifying requirements file under requirements dict parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -162,43 +162,8 @@ Deploying dependencies
 ----------------------
 
 Sometimes your project will depend on third party libraries that are not
-available on Scrapy Cloud. You can easily upload these via ``shub deploy-egg``
-by supplying a repository URL::
-
-    $ shub deploy-egg --from-url https://github.com/scrapinghub/dateparser.git
-    Cloning the repository to a tmp folder...
-    Building egg in: /tmp/egg-tmp-clone
-    Deploying dependency to Scrapy Cloud project "12345"
-    {"status": "ok", "egg": {"version": "v0.2.1-master", "name": "dateparser"}}
-    Deployed eggs list at: https://app.scrapinghub.com/p/12345/eggs
-
-Or even a specific branch if using git::
-
-    $ shub deploy-egg --from-url https://github.com/scrapinghub/dateparser.git --git-branch py3-port
-    Cloning the repository to a tmp folder...
-    py3-port branch was checked out
-    Building egg in: /tmp/egg-tmp-clone
-    Deploying dependency to Scrapy Cloud project "12345"
-    {"status": "ok", "egg": {"version": "v0.1.0-30-g48841f2-py3-port", "name": "dateparser"}}
-    Deployed eggs list at: https://app.scrapinghub.com/p/12345/eggs
-
-Or a package on PyPI::
-
-    $ shub deploy-egg --from-pypi loginform
-    Fetching loginform from pypi
-    Collecting loginform
-      Downloading loginform-1.0.tar.gz
-      Saved /tmp/shub/loginform-1.0.tar.gz
-    Successfully downloaded loginform
-    Package fetched successfully
-    Uncompressing: loginform-1.0.tar.gz
-    Building egg in: /tmp/shub/loginform-1.0
-    Deploying dependency to Scrapy Cloud project "12345"
-    {"status": "ok", "egg": {"version": "loginform-1.0", "name": "loginform"}}
-    Deployed eggs list at: https://app.scrapinghub.com/p/12345/eggs
-
-For projects that use Scrapy Cloud 2.0, instead of uploading eggs of your requirements, you
-can specify a requirements file to be used::
+available on Scrapy Cloud. You can easily upload these by specifying a
+requirements file::
 
     # project_directory/scrapinghub.yml
 
@@ -206,22 +171,44 @@ can specify a requirements file to be used::
       default: 12345
       prod: 33333
 
-    requirements_file: deploy_reqs.txt
+    requirements:
+      file: requirements.txt
 
 Note that this requirements file is an *extension* of the Scrapy Cloud stack, and
 therefore should not contain packages that are already part of the stack, such
 as ``scrapy``.
 
-You can specify the Scrapy Cloud stack to be used by extending the ``projects`` section
-of your configuration::
+When your dependencies cannot be specified in a requirements file, e.g.
+because they are not publicly available, you can supply them as Python eggs::
+
+    # project_directory/scrapinghub.yml
+
+    projects:
+      default: 12345
+      prod: 33333
+
+    requirements:
+      file: requirements.txt
+      eggs:
+        - privatelib.egg
+        - path/to/otherlib.egg
+
+
+Choosing a Scrapy Cloud stack
+-----------------------------
+
+You can specify the `Scrapy Cloud stack`_ to deploy your spider to by extending
+the ``projects`` section of your configuration::
 
     # project_directory/scrapinghub.yml
 
     projects:
       default:
         id: 12345
-        stack: portia
+        stack: scrapy:1.1-py3
       prod: 33333  # will use the original stack
+
+.. _`Scrapy Cloud stack`: http://doc.scrapinghub.com/scrapy-cloud.html#using-stacks
 
 
 Scheduling jobs and fetching job data

--- a/shub/config.py
+++ b/shub/config.py
@@ -67,9 +67,11 @@ class ShubConfig(object):
             for option in ('projects', 'endpoints', 'apikeys', 'stacks'):
                 getattr(self, option).update(yaml_cfg.get(option, {}))
             self.version = yaml_cfg.get('version', self.version)
-            if 'requirements_file' in yaml_cfg:
-                self.requirements_file = yaml_cfg['requirements_file']
-            self.eggs = yaml_cfg.get('requirements', {}).get('eggs', [])
+            self.requirements_file = yaml_cfg.get('requirements_file',
+                                                  self.requirements_file)
+            self.requirements_file = yaml_cfg.get('requirements', {}).get(
+                'file', self.requirements_file)
+            self.eggs = yaml_cfg.get('requirements', {}).get('eggs', self.eggs)
         except (yaml.YAMLError, AttributeError):
             # AttributeError: stream is valid YAML but not dictionary-like
             raise ConfigParseException
@@ -133,9 +135,10 @@ class ShubConfig(object):
             yml['version'] = self.version
             yml['stacks'] = self.stacks
             if self.eggs:
-                yml['requirements'] = {'eggs': self.eggs}
+                yml.setdefault('requirements', {})['eggs'] = self.eggs
             if self.requirements_file:
-                yml['requirements_file'] = self.requirements_file
+                yml.setdefault('requirements', {})['file'] = (
+                    self.requirements_file)
             # Don't write defaults
             if self.endpoints['default'] == ShubConfig.DEFAULT_ENDPOINT:
                 del yml['endpoints']['default']

--- a/shub/deploy_egg.py
+++ b/shub/deploy_egg.py
@@ -35,7 +35,7 @@ Alternatively, you can build the egg from a PyPI package:
     shub deploy-egg --from-pypi shub
 """
 
-SHORT_HELP = "Build and deploy egg from source"
+SHORT_HELP = "[DEPRECATED] Build and deploy egg from source"
 
 
 @click.command(help=HELP, short_help=SHORT_HELP)
@@ -44,6 +44,12 @@ SHORT_HELP = "Build and deploy egg from source"
 @click.option("--git-branch", help="Git branch to checkout")
 @click.option("--from-pypi", help="Name of package on pypi")
 def cli(target, from_url=None, git_branch=None, from_pypi=None):
+    click.secho(
+        "deploy-egg was deprecated, define the eggs you would like to deploy "
+        "in your scrapinghub.yml instead. See "
+        "http://doc.scrapinghub.com/shub.html#deploying-dependencies",
+        err=True, fg='yellow',
+    )
     main(target, from_url, git_branch, from_pypi)
 
 

--- a/shub/deploy_reqs.py
+++ b/shub/deploy_reqs.py
@@ -24,7 +24,7 @@ different file name with the -r option:
 The requirements file must be in a format parsable by pip.
 """
 
-SHORT_HELP = "Build and deploy eggs from requirements.txt"
+SHORT_HELP = "[DEPRECATED] Build and deploy eggs from requirements.txt"
 
 
 @click.command(help=HELP, short_help=SHORT_HELP)
@@ -32,6 +32,12 @@ SHORT_HELP = "Build and deploy eggs from requirements.txt"
 @click.option("-r", "--requirements-file", default='requirements.txt',
               type=click.STRING)
 def cli(target, requirements_file):
+    click.secho(
+        "deploy-reqs was deprecated, define a requirements file in your "
+        "scrapinghub.yml instead. See "
+        "http://doc.scrapinghub.com/shub.html#deploying-dependencies",
+        err=True, fg='yellow',
+    )
     main(target, requirements_file)
 
 


### PR DESCRIPTION
/cc @dangra are you ok with deprecating `deploy-egg` and `deploy-reqs` like this and removing them from the docs?