### PR TITLE
Add --tail functionality to log/items/requests

### DIFF
--- a/shub/items.py
+++ b/shub/items.py
@@ -39,7 +39,9 @@ SHORT_HELP = "Fetch items from Scrapy Cloud"
 @click.argument('job_id')
 @click.option('-f', '--follow', help='output new items as they are scraped',
               is_flag=True)
-def cli(job_id, follow):
+@click.option('-n', '--tail', help='output last N items only', type=int)
+def cli(job_id, follow, tail):
     job = get_job(job_id)
-    for item in job_resource_iter(job, job.items.iter_json, follow=follow):
+    for item in job_resource_iter(job, job.items, output_json=True,
+                                  follow=follow, tail=tail):
         click.echo(item)

--- a/shub/log.py
+++ b/shub/log.py
@@ -41,10 +41,10 @@ SHORT_HELP = "Fetch log from Scrapy Cloud"
 @click.argument('job_id')
 @click.option('-f', '--follow', help='output new log entries as they are '
               'produced', is_flag=True)
-def cli(job_id, follow):
+@click.option('-n', '--tail', help='output last N log entries only', type=int)
+def cli(job_id, follow, tail):
     job = get_job(job_id)
-    for item in job_resource_iter(job, job.logs.iter_values, follow=follow,
-                                  key_func=lambda item: item['_key']):
+    for item in job_resource_iter(job, job.logs, follow=follow, tail=tail):
         click.echo(
             u"{} {} {}".format(
                 datetime.utcfromtimestamp(item['time']/1000),

--- a/shub/requests.py
+++ b/shub/requests.py
@@ -39,7 +39,9 @@ SHORT_HELP = "Fetch requests from Scrapy Cloud"
 @click.argument('job_id')
 @click.option('-f', '--follow', help='output new requests as they are made',
               is_flag=True)
-def cli(job_id, follow):
+@click.option('-n', '--tail', help='output last N requests only', type=int)
+def cli(job_id, follow, tail):
     job = get_job(job_id)
-    for item in job_resource_iter(job, job.requests.iter_json, follow=follow):
+    for item in job_resource_iter(job, job.requests, output_json=True,
+                                  follow=follow, tail=tail):
         click.echo(item)


### PR DESCRIPTION
Adds the `-n/--tail` option to `shub log`, `shub items`, and `shub requests`. E.g., `shub log 1/1 -n 5` retrieves the five latest log entries.

Closes #195 
Kind of closes #122 