### PR TITLE
Drop ruamel.yaml in favour of PyYAML

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 click
+PyYAML
 requests
-ruamel.yaml
 six
 
 hubstorage

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,8 @@
 #
 click==6.6
 hubstorage==0.23.1
+PyYAML==3.12
 requests==2.10.0
 retrying==1.3.3           # via hubstorage
-ruamel.ordereddict==0.4.9; python_version == "2.6" or python_version == "2.7"  # via ruamel.yaml
-ruamel.yaml==0.11.14
 scrapinghub==1.7.0
 six==1.10.0

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     },
     include_package_data=True,
     zip_safe=False,
-    install_requires=['click', 'hubstorage', 'pip', 'requests', 'ruamel.yaml',
+    install_requires=['click', 'hubstorage', 'pip', 'requests', 'PyYAML',
                       'scrapinghub', 'six'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
@@ -28,6 +28,9 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Operating System :: OS Independent',
         'Environment :: Console',
         'Topic :: Internet :: WWW/HTTP',

--- a/shub/config.py
+++ b/shub/config.py
@@ -7,7 +7,7 @@ from collections import namedtuple
 
 import click
 import six
-import ruamel.yaml as yaml
+import yaml
 
 from shub.exceptions import (BadParameterException, BadConfigException,
                              ConfigParseException, MissingAuthException,
@@ -375,20 +375,17 @@ def load_shub_config(load_global=True, load_local=True, load_env=True):
 @contextlib.contextmanager
 def update_yaml_dict(conf_path=None):
     """
-    Context manager for updating a YAML file while preserving key ordering and
-    comments.
+    Context manager for updating a YAML file. Key ordering and comments are not
+    preserved.
     """
     conf_path = conf_path or GLOBAL_SCRAPINGHUB_YML_PATH
-    dumper = yaml.RoundTripDumper
     try:
         with open(conf_path, 'r') as f:
-            conf = yaml.load(f, yaml.RoundTripLoader) or {}
+            conf = yaml.safe_load(f) or {}
     except IOError as e:
         if e.errno != 2:
             raise
         conf = {}
-        # Use alphabetic order when creating files
-        dumper = yaml.Dumper
     # Code inside context manager is executed after this yield
     yield conf
     # Avoid writing "key: {}"
@@ -398,7 +395,7 @@ def update_yaml_dict(conf_path=None):
     with open(conf_path, 'w') as f:
         # Avoid writing "{}"
         if conf:
-            yaml.dump(conf, f, default_flow_style=False, Dumper=dumper)
+            yaml.dump(conf, f, default_flow_style=False)
 
 
 def get_target(target, auth_required=True):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,7 @@ import six
 import tempfile
 import textwrap
 import unittest
-import ruamel.yaml as yaml
+import yaml
 
 import mock
 
@@ -614,31 +614,27 @@ class ConfigHelpersTest(unittest.TestCase):
 
     def test_update_yaml_dict(self):
         YAML_BEFORE = textwrap.dedent("""\
-            z_first:
+            a:
               unrelated: dict
-            a_second:
+            b:
               key1: val1
-              # some comment
               key2: val2
         """)
-        YAML_EXPECTED = textwrap.dedent("""\
-            z_first:
-              unrelated: dict
-            a_second:
-              key1: newval1
-              # some comment
-              key2: val2
-              key3: val3
-        """)
+        DICT_EXPECTED = {
+            'a': {'unrelated': 'dict'},
+            'b': {'key1': 'newval1', 'key2': 'val2', 'key3': 'val3'}
+        }
         runner = CliRunner()
         with runner.isolated_filesystem():
             with open('conf.yml', 'w') as f:
                 f.write(YAML_BEFORE)
             with update_yaml_dict('conf.yml') as conf:
-                conf['a_second']['key1'] = 'newval1'
-                conf['a_second']['key3'] = 'val3'
+                conf['b']['key1'] = 'newval1'
+                conf['b']['key3'] = 'val3'
             with open('conf.yml', 'r') as f:
-                self.assertEqual(f.read(), YAML_EXPECTED)
+                self.assertEqual(yaml.safe_load(f), DICT_EXPECTED)
+                f.seek(0)
+                self.assertIn("key1: newval1", f.read())
 
     @mock.patch('shub.config.load_shub_config')
     def test_get_target_version(self, mock_lsh):

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -4,7 +4,7 @@ from mock import patch, MagicMock
 import textwrap
 
 from click.testing import CliRunner
-import ruamel.yaml as yaml
+import yaml
 
 from shub import login
 from shub.exceptions import AlreadyLoggedInException

--- a/tests/test_migrate_eggs.py
+++ b/tests/test_migrate_eggs.py
@@ -2,7 +2,7 @@ import os
 import unittest
 import mock
 
-import ruamel.yaml as yaml
+import yaml
 from click.testing import CliRunner
 
 from shub.migrate_eggs import main


### PR DESCRIPTION
`ruamel.yaml` was giving trouble for Windows users sometimes. It's also a bit of an obscure dependency, so I think we should revert to upstream.

The implication of this is that key ordering and comments will no longer be preserved when we update YAML files. As it's rare that a config file is edited manually and then written automatically to afterwards, this shouldn't be much of a deal.