### PR TITLE
Add __main__.py to allow invoking shub with python -m shub

### DIFF
--- a/freeze/shubrunner.py
+++ b/freeze/shubrunner.py
@@ -1,5 +1,0 @@
-from __future__ import absolute_import
-import shub.tool
-
-# Run cli
-shub.tool.cli()

--- a/shub/__main__.py
+++ b/shub/__main__.py
@@ -1,0 +1,13 @@
+from __future__ import absolute_import
+
+import os
+import sys
+
+import shub.tool
+
+
+prog_name = os.path.basename(sys.argv and sys.argv[0] or __file__)
+if prog_name == '__main__.py':
+    # shub invoked via python -m shub
+    prog_name = __package__
+shub.tool.cli(prog_name=prog_name)

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,6 @@ deps =
     pytest
     pytest-catchlog
 commands =
-    pyinstaller --clean -y -F -n shub --distpath=./dist_bin --additional-hooks-dir=./freeze/hooks --runtime-hook=./freeze/hooks/runtime-hooks.py --icon=./freeze/spider-down.ico ./freeze/shubrunner.py
+    pyinstaller --clean -y -F -n shub --distpath=./dist_bin --additional-hooks-dir=./freeze/hooks --runtime-hook=./freeze/hooks/runtime-hooks.py --icon=./freeze/spider-down.ico ./shub/__main__.py
     py.test {toxinidir}/freeze/tests/run.py
 


### PR DESCRIPTION
`python -m shub` is useful during development (when I explicitly don't want to run `/usr/bin/shub`) and when `/usr/bin/shub` (or the Windows equivalent) was for some reason not created (from what I gather this might happen on Mac machines sometimes).