### PR TITLE
Clean version string with pattern

### DIFF
--- a/shub/utils.py
+++ b/shub/utils.py
@@ -179,6 +179,7 @@ def pwd_version():
                 ver = _last_line_of(run_python([setuppy, '--version']))
     if not ver:
         ver = str(int(time.time()))
+    ver = re.sub(r'[^\w.-]+', '', ver)
     return ver
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -79,6 +79,17 @@ class UtilsTest(unittest.TestCase):
             open('../scrapy.cfg', 'w').close()
             self.assertEqual(utils.pwd_version(), '1.0')
 
+    @patch('shub.utils.pwd_git_version')
+    def test_pwd_version_clean(self, mock_git):
+        mock_git.return_value = 'vers_1'
+        self.assertEqual(utils.pwd_version(), 'vers_1')
+        mock_git.return_value = 've  rs _ 2'
+        self.assertEqual(utils.pwd_version(), 'vers_2')
+        mock_git.return_value = 'vers -3_1:1'
+        self.assertEqual(utils.pwd_version(), 'vers-3_11')
+        mock_git.return_value = 'vers -4_1!$@%#&$()2'
+        self.assertEqual(utils.pwd_version(), 'vers-4_12')
+
     def test_get_job_specs(self):
         conf = mock_conf(self)
 


### PR DESCRIPTION
Dash logic has pattern matching to check correctness of version string on deploy, and in some cases will deploy reject requests from shub tool due to spaces or some other forbidden chars (for example SVN allows using spaces in a branch name). Let's polish clients experience and clean version string before doing any external requests.
 
Review, please.