### PR TITLE
Add -h option to get help message

### DIFF
--- a/shub/tool.py
+++ b/shub/tool.py
@@ -21,8 +21,11 @@ For usage and help on a specific command, run it with a --help flag, e.g.:
     shub schedule --help
 """
 
+CONTEXT_SETTINGS = {'help_option_names': ['-h', '--help']}
 
-@click.group(help=HELP, short_help=SHORT_HELP, epilog=EPILOG)
+
+@click.group(help=HELP, short_help=SHORT_HELP, epilog=EPILOG,
+             context_settings=CONTEXT_SETTINGS)
 @click.version_option(shub.__version__)
 def cli():
     update_url = update_available()


### PR DESCRIPTION
It's a very popular option for getting a help message, can't help but use it, it's already a muscle memory I guess. So annoying that click doesn't have it by default.