### PR TITLE
image test: drop check for sh-ep-scrapy

### DIFF
--- a/shub/image/test.py
+++ b/shub/image/test.py
@@ -12,22 +12,20 @@ A command to test an image after build step to make sure it fits contract.
 It consists of the following steps:
 
 1) check that image exists on local machine
-2) check that image has scrapinghub-entrypoint-scrapy python package
-3) check that image has start-crawl entrypoint
-4) check that image has list-spiders entrypoint
-
-These entrypoints are provided by scrapinghub-entrypoint-scrapy package,
-so the goal of the last checks is to validate the package version.
+2) check that image has start-crawl entrypoint
+3) check that image has list-spiders entrypoint
 
 If any of the checks fails - the test command fails as a whole. By default,
 the test command is also executed automatically as a part of build command
-in its end (if you do not provide --skip-tests parameter explicitly).
+in its end (if you do not provide -S/--skip-tests parameter explicitly).
 """
 
-SH_EP_SCRAPY_WARNING = \
-    'You should add scrapinghub-entrypoint-scrapy(>=0.8.0) dependency' \
-    ' to your requirements.txt or to Dockerfile to run the image with' \
-    ' Scrapy Cloud.'
+CONTRACT_CMD_NOT_FOUND_WARNING = \
+    'Command %s is not found in the image. ' \
+    'Please make sure you provided it according to Scrapy Cloud contract ' \
+    '(https://shub.readthedocs.io/en/stable/custom-images-contract.html) ' \
+    'or added scrapinghub-entrypoint-scrapy>=0.8.0 to your requirements ' \
+    'file if you use Scrapy.'
 
 
 @click.command(help=HELP, short_help=SHORT_HELP)
@@ -72,8 +70,7 @@ def _check_list_spiders_entry(image_name, docker_client):
         docker_client, image_name, ['which', 'list-spiders'])
     if status != 0 or not logs:
         raise shub_exceptions.NotFoundException(
-            "list-spiders command is not found in the image.\n"
-            "Please upgrade your scrapinghub-entrypoint-scrapy(>=0.7.0)")
+            CONTRACT_CMD_NOT_FOUND_WARNING % 'list-spiders')
 
 
 def _check_start_crawl_entry(image_name, docker_client):
@@ -82,8 +79,7 @@ def _check_start_crawl_entry(image_name, docker_client):
         docker_client, image_name, ['which', 'start-crawl'])
     if status != 0 or not logs:
         raise shub_exceptions.NotFoundException(
-            "start-crawl command is not found in the image.\n"
-            + SH_EP_SCRAPY_WARNING)
+            CONTRACT_CMD_NOT_FOUND_WARNING % 'start-crawl')
 
 
 def _run_docker_command(client, image_name, command):

--- a/shub/image/test.py
+++ b/shub/image/test.py
@@ -25,7 +25,7 @@ in its end (if you do not provide --skip-tests parameter explicitly).
 """
 
 SH_EP_SCRAPY_WARNING = \
-    'You should add scrapinghub-entrypoint-scrapy(>=0.7.0) dependency' \
+    'You should add scrapinghub-entrypoint-scrapy(>=0.8.0) dependency' \
     ' to your requirements.txt or to Dockerfile to run the image with' \
     ' Scrapy Cloud.'
 
@@ -49,8 +49,7 @@ def test_cmd(target, version):
     docker_client = utils.get_docker_client()
     for check in [_check_image_exists,
                   _check_start_crawl_entry,
-                  _check_list_spiders_entry,
-                  _check_sh_entrypoint]:
+                  _check_list_spiders_entry]:
         check(image_name, docker_client)
 
 
@@ -65,19 +64,6 @@ def _check_image_exists(image_name, docker_client):
         utils.debug_log("{}".format(exc))
         raise shub_exceptions.NotFoundException(
             "The image doesn't exist yet, please use build command at first.")
-
-
-def _check_sh_entrypoint(image_name, docker_client):
-    """Check that the image has scrapinghub-entrypoint-scrapy pkg"""
-    status, logs = _run_docker_command(
-        docker_client, image_name, ['pip', 'show', 'Scrapy'])
-    # doesn't make sense to check sh-ep-scrapy if there's no Scrapy
-    if status == 0 and logs:
-        status, logs = _run_docker_command(
-            docker_client, image_name,
-            ['pip', 'show', 'scrapinghub-entrypoint-scrapy'])
-        if status != 0 or not logs:
-            raise shub_exceptions.NotFoundException(SH_EP_SCRAPY_WARNING)
 
 
 def _check_list_spiders_entry(image_name, docker_client):

--- a/shub/image/test.py
+++ b/shub/image/test.py
@@ -20,12 +20,13 @@ the test command is also executed automatically as a part of build command
 in its end (if you do not provide -S/--skip-tests parameter explicitly).
 """
 
-CONTRACT_CMD_NOT_FOUND_WARNING = \
-    'Command %s is not found in the image. ' \
-    'Please make sure you provided it according to Scrapy Cloud contract ' \
-    '(https://shub.readthedocs.io/en/stable/custom-images-contract.html) ' \
-    'or added scrapinghub-entrypoint-scrapy>=0.8.0 to your requirements ' \
-    'file if you use Scrapy.'
+CONTRACT_CMD_NOT_FOUND_WARNING = (
+    'Command %s is not found in the image. '
+    'Please make sure you provided it according to Scrapy Cloud contract '
+    '(https://shub.readthedocs.io/en/stable/custom-images-contract.html) or '
+    'added scrapinghub-entrypoint-scrapy>=0.8.0 to your requirements file '
+    'if you use Scrapy.'
+)
 
 
 @click.command(help=HELP, short_help=SHORT_HELP)

--- a/tests/image/test_test.py
+++ b/tests/image/test_test.py
@@ -49,18 +49,27 @@ def test_check_image_exists(monkeypatch, docker_client):
 
 
 def test_check_sh_entrypoint(docker_client):
+    # scrapy/sh-ep-scrapy exists, everything is fine
     assert _check_sh_entrypoint('image', docker_client) is None
-    docker_client.create_container.assert_called_with(
-        image='image',
-        command=['pip', 'show', 'scrapinghub-entrypoint-scrapy'])
-    docker_client.wait.return_value = 1
+    docker_client.create_container.assert_has_calls([
+        mock.call(image='image', command=['pip', 'show', 'Scrapy']),
+        mock.call(image='image', command=[
+            'pip', 'show', 'scrapinghub-entrypoint-scrapy'])])
+
+    # scrapy is here, but no sh-ep-scrapy (failed command)
+    docker_client.wait.side_effect = [0, 1]
+    with pytest.raises(shub_exceptions.NotFoundException):
+        _check_sh_entrypoint('image', docker_client)
+    # scrapy is here, but no sh-ep-scrapy (no logs)
+    docker_client.wait.side_effect = [0, 0]
+    docker_client.logs.side_effect = ['some-log', '']
     with pytest.raises(shub_exceptions.NotFoundException):
         _check_sh_entrypoint('image', docker_client)
 
-    docker_client.wait.return_value = 0
-    docker_client.logs.return_value = ''
-    with pytest.raises(shub_exceptions.NotFoundException):
-        _check_sh_entrypoint('image', docker_client)
+    # no scrapy -> nothing to check
+    docker_client.wait.side_effect = [1, 0]
+    docker_client.logs.side_effect = ['error', 'logs']
+    _check_sh_entrypoint('image', docker_client)
 
 
 def test_start_crawl(docker_client):
@@ -88,3 +97,4 @@ def test_run_docker_command(docker_client):
     docker_client.logs.assert_called_with(
         container='12345', stdout=True, stderr=False,
         stream=False, timestamps=False)
+    docker_client.remove_container.assert_called_with({'Id': '12345'})


### PR DESCRIPTION
Drop redundant check for sh-ep-scrapy.

Initial intention before https://github.com/scrapinghub/shub/pull/229#issuecomment-276886774 was to check for `scrapinghub-entrypoint-scrapy` only if there's Scrapy installed, but it doesn't play nice with non-python code.

I also noticed that we don't clean temporary containers after tests, let's improve it as well.