### PR TITLE
Enable tests for Python 3.6

### DIFF
--- a/.travis-workarounds.sh
+++ b/.travis-workarounds.sh
@@ -14,17 +14,10 @@ fi
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     brew update > /dev/null
 
-    brew reinstall python
-
-    # Now easy_install and pip are in /usr/local we need to force link
-    brew unlink python && brew link --overwrite python
+    brew install zoidbergwill/python/python35
 
     PATH="/usr/local/bin:$PATH"
 
     # Use brew python for virtualenv
-    /usr/local/bin/virtualenv -p /usr/local/bin/python ~/virtualenv/python2.7
-
+    /usr/local/bin/virtualenv -p /usr/local/bin/python3.5 ~/virtualenv/python3.5
 fi
-
-# Workaround travis-ci/travis-ci#2065
-pip install -U wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ env:
 
 matrix:
   include:
+    - python: 3.6
+      env: TOX_ENV=py36
     - os: osx
       # Using "generic" because osx in Travis doesn't support python
       language: generic

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ branches:
 
 install:
   - "./.travis-workarounds.sh"
-  - '[ "$TRAVIS_OS_NAME" != osx ] || source ~/virtualenv/python2.7/bin/activate'
+  - '[ "$TRAVIS_OS_NAME" != osx ] || source ~/virtualenv/python3.5/bin/activate'
   - pip install -U tox twine wheel codecov
 
 script: tox -e $TOX_ENV

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,8 @@ environment:
       TOX_ENV: py27
     - PYTHON: "C:\\Python35"
       TOX_ENV: py35
+    - PYTHON: "C:\\Python36"
+      TOX_ENV: py36
     - PYTHON: "C:\\Python35"
       TOX_ENV: freeze
 

--- a/shub/image/utils.py
+++ b/shub/image/utils.py
@@ -145,7 +145,7 @@ def store_status_url(status_url, limit):
     status_id = max(data.keys()) + 1
     data[status_id] = status_url
     if len(data) > limit:
-        data.popitem()
+        del data[min(data.keys())]
     _update_status_file(data, STATUS_FILE_LOCATION)
     return status_id
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35
+envlist = py27,py33,py34,py35,py36
 
 [testenv]
 setenv =


### PR DESCRIPTION
Plus a small fix for `shub image check`: Previously, when updating the temporary file with status urls in `shub image check` once the line limit for that file had been reached, an _arbitrary_ line was removed via `dict.popitem()`. Because of an implementation detail in CPython, this used to fall in line with what we wanted, deleting the oldest entry. The fix makes sure we always explicitly delete the oldest entry. (The `dict` implementation has changed in CPython 3.6 and would now delete the newest dictionary entry instead.)