### PR TITLE
Unify calling subcommands

### DIFF
--- a/shub/deploy.py
+++ b/shub/deploy.py
@@ -1,11 +1,9 @@
 from __future__ import absolute_import
 import os
-import sys
 import glob
 import shutil
 import tempfile
 from six.moves.urllib.parse import urljoin
-from subprocess import check_call
 
 import click
 # Not used in code but needed in runtime, don't remove!
@@ -26,8 +24,7 @@ from shub.config import load_shub_config, update_yaml_dict
 from shub.exceptions import (InvalidAuthException, NotFoundException,
                              RemoteErrorException, ShubException)
 from shub.utils import (closest_file, get_config, inside_project,
-                        make_deploy_request, patch_sys_executable,
-                        retry_on_eintr)
+                        make_deploy_request, run_python)
 
 
 HELP = """
@@ -175,14 +172,7 @@ def _build_egg():
         settings = get_config().get('settings', 'default')
         _create_default_setup_py(settings=settings)
     d = tempfile.mkdtemp(prefix="shub-deploy-")
-    with open(os.path.join(d, "stdout"), "wb") as o, \
-            open(os.path.join(d, "stderr"), "wb") as e, \
-            patch_sys_executable():
-        retry_on_eintr(
-            check_call,
-            [sys.executable, 'setup.py', 'clean', '-a', 'bdist_egg', '-d', d],
-            stdout=o, stderr=e,
-        )
+    run_python(['setup.py', 'clean', '-a', 'bdist_egg', '-d', d])
     egg = glob.glob(os.path.join(d, '*.egg'))[0]
     return egg, d
 

--- a/shub/exceptions.py
+++ b/shub/exceptions.py
@@ -54,6 +54,11 @@ class BadParameterException(BadParameter):
     exit_code = 64  # EX_USAGE
 
 
+class SubcommandException(ShubException):
+    exit_code = 65  # EX_DATAERR
+    default_msg = "Error while calling subcommand."
+
+
 class RemoteErrorException(ShubException):
     exit_code = 76  # EX_PROTOCOL
     # Should be initialised with more specific message

--- a/tests/test_deploy_egg.py
+++ b/tests/test_deploy_egg.py
@@ -11,6 +11,7 @@ import shutil
 from zipfile import ZipFile
 
 from shub import deploy_egg
+from shub.exceptions import BadParameterException
 
 
 class FakeRequester:
@@ -66,6 +67,21 @@ class TestDeployEgg(unittest.TestCase):
         branch = 'dev'
         data = self.call_main_and_check_request_data(from_url=repo, git_branch=branch)
         self.assertTrue('dev' in data['version'])
+
+    def test_fails_on_invalid_repo(self):
+        self._unzip_git_repo_to(self.tmp_dir)
+        repo = os.path.join(self.tmp_dir, 'deploy_egg_sample_repo.git')
+        shutil.rmtree(os.path.join(repo, '.git'))
+
+        with self.assertRaises(BadParameterException):
+            self.call_main_and_check_request_data(from_url=repo)
+
+    def test_fails_on_invalid_branch(self):
+        self._unzip_git_repo_to(self.tmp_dir)
+        repo = os.path.join(self.tmp_dir, 'deploy_egg_sample_repo.git')
+        with self.assertRaises(BadParameterException):
+            self.call_main_and_check_request_data(
+                from_url=repo, git_branch='nonexisting')
 
     def _unzip_git_repo_to(self, path):
         zipped_repo = os.path.abspath('tests/samples/deploy_egg_sample_repo.git.zip')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -50,6 +50,13 @@ class UtilsTest(unittest.TestCase):
         with self.assertRaises(NotFoundException):
             utils.find_exe('python')
 
+    def test_pwd_git_version_without_git(self):
+        # Change into test dir to make sure we're within a repo
+        os.chdir(os.path.dirname(__file__))
+        self.assertIsNotNone(utils.pwd_git_version())
+        with patch('shub.utils.find_executable', return_value=None):
+            self.assertIsNone(utils.pwd_git_version())
+
     @patch('shub.utils.pwd_git_version', return_value='ver_GIT')
     @patch('shub.utils.pwd_hg_version', return_value='ver_HG')
     @patch('shub.utils.pwd_bzr_version', return_value='ver_BZR')


### PR DESCRIPTION
We had a couple of different implementations and helpers for calling subprocesses floating around, this PR unifies them.

It also removes the "Retry on EINTR" functionality as that has been [included in CPython](https://www.python.org/dev/peps/pep-0475/).