### PR TITLE
Rename 'shub-image' to 'shub image' in messages and docstrings

### DIFF
--- a/shub/image/build.py
+++ b/shub/image/build.py
@@ -51,7 +51,7 @@ def build_cmd(target, version, skip_tests):
     image_name = utils.format_image_name(image, version)
     if not os.path.exists(os.path.join(project_dir, 'Dockerfile')):
         raise shub_exceptions.BadParameterException(
-            'Dockerfile is not found, please use shub-image init cmd')
+            "Dockerfile is not found, please use shub image 'init' command")
     is_built = False
     for data in client.build(path=project_dir, tag=image_name, decode=True):
         if 'stream' in data:

--- a/shub/image/deploy.py
+++ b/shub/image/deploy.py
@@ -98,7 +98,7 @@ def deploy_cmd(target, version, username, password, email,
         status_url, limit=STORE_N_LAST_STATUS_URLS)
     click.echo(
         "You can check deploy results later with "
-        "'shub-image check --id {}'.".format(status_id))
+        "'shub image check --id {}'.".format(status_id))
 
     click.echo("Deploy results:")
     actual_state = _check_status_url(status_url)

--- a/shub/image/init.py
+++ b/shub/image/init.py
@@ -55,7 +55,7 @@ via --requirements option, we'll create new requirements.txt in the
 project_dir with the recommended deps(use --list-recommended-reqs to list it).
 
 You should also include scrapinghub-entrypoint-scrapy package to your py-reqs,
-it's a necessary condition to run your project with Kumo (use shub-image test
+it's a necessary condition to run your project with Kumo (use 'shub image test'
 to check if your image fits our expectations).
 """.format(BASE_SYSTEM_DEPS)
 

--- a/shub/image/utils.py
+++ b/shub/image/utils.py
@@ -19,7 +19,7 @@ DOCKER_UNAVAILABLE_MSG = """
 Detected error connecting to Docker daemon's host.
 
 Please ensure that you have Docker installed, configured and running locally,
-that's essential for running shub-image tool. To check that run command
+that's essential for running shub image command. To check that run command
 
     docker version
 


### PR DESCRIPTION
Some messages and docstrings still refer to the legacy `shub-image` tool, such as this message I got when deploying an image:

    You can check deploy results later with 'shub-image check --id 0'.

This PR fixes those.