### PR TITLE
Test image before `shub image push`

### DIFF
--- a/shub/image/build.py
+++ b/shub/image/build.py
@@ -9,7 +9,7 @@ from shub.deploy import _create_default_setup_py
 from shub.utils import closest_file, get_config
 from shub.config import load_shub_config
 from shub.image import utils
-from shub.image import test as test_mod
+from shub.image import test as test_cmd
 
 
 SHORT_HELP = 'Build release image.'
@@ -67,7 +67,7 @@ def build_cmd(target, version, skip_tests):
     click.echo("The image {} build is completed.".format(image_name))
     # Test the image content after building it
     if not skip_tests:
-        test_mod.test_cmd(target, version)
+        test_cmd.test_cmd(target, version)
 
 
 def _create_setup_py_if_not_exists():

--- a/shub/image/push.py
+++ b/shub/image/push.py
@@ -31,12 +31,12 @@ otherwise you have to enter your credentials (at least username/password).
 @click.option("-v", "--verbose", is_flag=True,
               help="stream push logs to console")
 @click.option("-V", "--version", help="release version")
-@click.option("-S", "--skip-tests", help="skip testing image", is_flag=True)
 @click.option("--username", help="docker registry name")
 @click.option("--password", help="docker registry password")
 @click.option("--email", help="docker registry email")
 @click.option("--apikey", help="SH apikey to use built-in registry")
 @click.option("--insecure", is_flag=True, help="use insecure registry")
+@click.option("-S", "--skip-tests", help="skip testing image", is_flag=True)
 def cli(target, debug, verbose, version, username, password, email, apikey,
         insecure, skip_tests):
     push_cmd(target, version, username, password, email, apikey, insecure, skip_tests)

--- a/shub/image/push.py
+++ b/shub/image/push.py
@@ -4,6 +4,7 @@ from shub.deploy import list_targets
 from shub import exceptions as shub_exceptions
 from shub.config import load_shub_config
 from shub.image import utils
+from shub.image import test as test_cmd
 
 SHORT_HELP = 'Push an image to a specified docker registry'
 
@@ -30,17 +31,22 @@ otherwise you have to enter your credentials (at least username/password).
 @click.option("-v", "--verbose", is_flag=True,
               help="stream push logs to console")
 @click.option("-V", "--version", help="release version")
+@click.option("-S", "--skip-tests", help="skip testing image", is_flag=True)
 @click.option("--username", help="docker registry name")
 @click.option("--password", help="docker registry password")
 @click.option("--email", help="docker registry email")
 @click.option("--apikey", help="SH apikey to use built-in registry")
 @click.option("--insecure", is_flag=True, help="use insecure registry")
 def cli(target, debug, verbose, version, username, password, email, apikey,
-        insecure):
-    push_cmd(target, version, username, password, email, apikey, insecure)
+        insecure, skip_tests):
+    push_cmd(target, version, username, password, email, apikey, insecure, skip_tests)
 
 
-def push_cmd(target, version, username, password, email, apikey, insecure):
+def push_cmd(target, version, username, password, email, apikey, insecure, skip_tests):
+    # Test the image content after building it
+    if not skip_tests:
+        test_cmd.test_cmd(target, version)
+
     client = utils.get_docker_client()
     config = load_shub_config()
     image = config.get_image(target)

--- a/shub/image/upload.py
+++ b/shub/image/upload.py
@@ -36,6 +36,8 @@ Obviously it accepts all the options for the commands above.
 def cli(target, debug, verbose, version, username, password, email,
         apikey, insecure, async, skip_tests):
     build.build_cmd(target, version, skip_tests)
-    push.push_cmd(target, version, username, password, email, apikey, insecure)
+    # skip tests for push command anyway because they run in build command if not skipped
+    push.push_cmd(target, version, username, password, email, apikey,
+                  insecure, skip_tests=True)
     deploy.deploy_cmd(target, version, username, password, email,
                       apikey, insecure, async)

--- a/tests/image/conftest.py
+++ b/tests/image/conftest.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+import mock
+import pytest
+
+
+@pytest.fixture
+def docker_client_mock():
+    client_mock = mock.Mock()
+    with mock.patch('shub.image.utils.get_docker_client') as m:
+        m.return_value = client_mock
+        yield client_mock
+
+
+@pytest.fixture
+def test_mock():
+    with mock.patch('shub.image.test.test_cmd') as m:
+        yield m

--- a/tests/image/conftest.py
+++ b/tests/image/conftest.py
@@ -2,9 +2,14 @@
 import mock
 import pytest
 
+from .utils import (
+    FakeProjectDirectory, add_scrapy_fake_config, add_sh_fake_config,
+    add_fake_dockerfile
+)
 
 @pytest.fixture
 def docker_client_mock():
+    """Docker client mock"""
     client_mock = mock.Mock()
     with mock.patch('shub.image.utils.get_docker_client') as m:
         m.return_value = client_mock
@@ -13,5 +18,16 @@ def docker_client_mock():
 
 @pytest.fixture
 def test_mock():
+    """Mock for shub image test command"""
     with mock.patch('shub.image.test.test_cmd') as m:
         yield m
+
+
+@pytest.fixture
+def project_dir():
+    """Fake project directory"""
+    with FakeProjectDirectory() as tmpdir:
+        add_scrapy_fake_config(tmpdir)
+        add_sh_fake_config(tmpdir)
+        add_fake_dockerfile(tmpdir)
+        yield tmpdir

--- a/tests/image/test_build.py
+++ b/tests/image/test_build.py
@@ -1,7 +1,6 @@
 import os
-import mock
+
 from click.testing import CliRunner
-from unittest import TestCase
 from shub import exceptions as shub_exceptions
 from shub.image.build import cli
 
@@ -11,71 +10,64 @@ from .utils import add_fake_dockerfile
 from .utils import add_scrapy_fake_config
 
 
-@mock.patch('shub.image.utils.get_docker_client')
-class TestBuildCli(TestCase):
+def test_cli(docker_client_mock, test_mock):
+    docker_client_mock.build.return_value = [
+        {"stream": "all is ok"},
+        {"stream": "Successfully built 12345"}
+    ]
+    with FakeProjectDirectory() as tmpdir:
+        add_scrapy_fake_config(tmpdir)
+        add_sh_fake_config(tmpdir)
+        add_fake_dockerfile(tmpdir)
+        setup_py_path = os.path.join(tmpdir, 'setup.py')
+        assert not os.path.isfile(setup_py_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["dev", "-v"])
+        assert result.exit_code == 0
+        docker_client_mock.build.assert_called_with(
+            decode=True, path=tmpdir, tag='registry/user/project:1.0')
+        assert os.path.isfile(setup_py_path)
+    test_mock.assert_called_with("dev", None)
 
-    @mock.patch('shub.image.test.test_cmd')
-    def test_cli(self, test_mock, mocked_method):
-        mocked = mock.MagicMock()
-        mocked.build.return_value = [
-            {"stream": "all is ok"},
-            {"stream": "Successfully built 12345"}]
-        mocked_method.return_value = mocked
-        with FakeProjectDirectory() as tmpdir:
-            add_scrapy_fake_config(tmpdir)
-            add_sh_fake_config(tmpdir)
-            add_fake_dockerfile(tmpdir)
-            setup_py_path = os.path.join(tmpdir, 'setup.py')
-            assert not os.path.isfile(setup_py_path)
-            runner = CliRunner()
-            result = runner.invoke(cli, ["dev", "-v"])
-            assert result.exit_code == 0
-            mocked.build.assert_called_with(
-                decode=True, path=tmpdir, tag='registry/user/project:1.0')
-            assert os.path.isfile(setup_py_path)
-            test_mock.assert_called_with("dev", None)
 
-    @mock.patch('shub.image.test.test_cmd')
-    def test_cli_custom_version(self, test_mock, mocked_method):
-        mocked = mock.MagicMock()
-        mocked.build.return_value = [
-            {"stream": "all is ok"},
-            {"stream": "Successfully built 12345"}]
-        mocked_method.return_value = mocked
-        with FakeProjectDirectory() as tmpdir:
-            add_scrapy_fake_config(tmpdir)
-            add_sh_fake_config(tmpdir)
-            add_fake_dockerfile(tmpdir)
-            runner = CliRunner()
-            result = runner.invoke(cli, ["dev", "--version", "test"])
-            assert result.exit_code == 0
-            mocked.build.assert_called_with(
-                decode=True, path=tmpdir, tag='registry/user/project:test')
-            test_mock.assert_called_with("dev", "test")
+def test_cli_custom_version(docker_client_mock, test_mock):
+    docker_client_mock.build.return_value = [
+        {"stream": "all is ok"},
+        {"stream": "Successfully built 12345"}]
+    with FakeProjectDirectory() as tmpdir:
+        add_scrapy_fake_config(tmpdir)
+        add_sh_fake_config(tmpdir)
+        add_fake_dockerfile(tmpdir)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["dev", "--version", "test"])
+        assert result.exit_code == 0
+        docker_client_mock.build.assert_called_with(
+            decode=True, path=tmpdir, tag='registry/user/project:test')
+    test_mock.assert_called_with("dev", "test")
 
-    def test_cli_no_dockerfile(self, mocked_method):
-        mocked = mock.MagicMock()
-        mocked.build.return_value = [
-            {"error": "Minor", "errorDetail": "Testing output"},
-            {"stream": "Successfully built 12345"}]
-        mocked_method.return_value = mocked
-        with FakeProjectDirectory() as tmpdir:
-            add_scrapy_fake_config(tmpdir)
-            add_sh_fake_config(tmpdir)
-            runner = CliRunner()
-            result = runner.invoke(cli, ["dev"])
-            assert result.exit_code == \
-                shub_exceptions.BadParameterException.exit_code
 
-    def test_cli_fail(self, mocked_method):
-        mocked = mock.MagicMock()
-        mocked.build.return_value = [{"error": "Minor", "errorDetail": "Test"}]
-        mocked_method.return_value = mocked
-        with FakeProjectDirectory() as tmpdir:
-            add_scrapy_fake_config(tmpdir)
-            add_sh_fake_config(tmpdir)
-            add_fake_dockerfile(tmpdir)
-            runner = CliRunner()
-            result = runner.invoke(cli, ["dev"])
-            assert result.exit_code == \
-                shub_exceptions.RemoteErrorException.exit_code
+def test_cli_no_dockerfile(docker_client_mock):
+    docker_client_mock.build.return_value = [
+        {"error": "Minor", "errorDetail": "Testing output"},
+        {"stream": "Successfully built 12345"}]
+    with FakeProjectDirectory() as tmpdir:
+        add_scrapy_fake_config(tmpdir)
+        add_sh_fake_config(tmpdir)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["dev"])
+        assert result.exit_code == \
+            shub_exceptions.BadParameterException.exit_code
+
+
+def test_cli_fail(docker_client_mock):
+    docker_client_mock.build.return_value = [
+        {"error": "Minor", "errorDetail": "Test"}
+    ]
+    with FakeProjectDirectory() as tmpdir:
+        add_scrapy_fake_config(tmpdir)
+        add_sh_fake_config(tmpdir)
+        add_fake_dockerfile(tmpdir)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["dev"])
+        assert result.exit_code == \
+            shub_exceptions.RemoteErrorException.exit_code

--- a/tests/image/test_build.py
+++ b/tests/image/test_build.py
@@ -1,73 +1,72 @@
 import os
 
+import pytest
 from click.testing import CliRunner
 from shub import exceptions as shub_exceptions
 from shub.image.build import cli
 
-from .utils import FakeProjectDirectory
-from .utils import add_sh_fake_config
-from .utils import add_fake_dockerfile
-from .utils import add_scrapy_fake_config
 
-
-def test_cli(docker_client_mock, test_mock):
+def test_cli(docker_client_mock, project_dir, test_mock):
     docker_client_mock.build.return_value = [
         {"stream": "all is ok"},
         {"stream": "Successfully built 12345"}
     ]
-    with FakeProjectDirectory() as tmpdir:
-        add_scrapy_fake_config(tmpdir)
-        add_sh_fake_config(tmpdir)
-        add_fake_dockerfile(tmpdir)
-        setup_py_path = os.path.join(tmpdir, 'setup.py')
-        assert not os.path.isfile(setup_py_path)
-        runner = CliRunner()
-        result = runner.invoke(cli, ["dev", "-v"])
-        assert result.exit_code == 0
-        docker_client_mock.build.assert_called_with(
-            decode=True, path=tmpdir, tag='registry/user/project:1.0')
-        assert os.path.isfile(setup_py_path)
+    setup_py_path = os.path.join(project_dir, 'setup.py')
+    assert not os.path.isfile(setup_py_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["dev", "-v"])
+    assert result.exit_code == 0
+    docker_client_mock.build.assert_called_with(
+        decode=True, path=project_dir, tag='registry/user/project:1.0')
+    assert os.path.isfile(setup_py_path)
     test_mock.assert_called_with("dev", None)
 
 
-def test_cli_custom_version(docker_client_mock, test_mock):
+def test_cli_custom_version(docker_client_mock, project_dir, test_mock):
     docker_client_mock.build.return_value = [
         {"stream": "all is ok"},
-        {"stream": "Successfully built 12345"}]
-    with FakeProjectDirectory() as tmpdir:
-        add_scrapy_fake_config(tmpdir)
-        add_sh_fake_config(tmpdir)
-        add_fake_dockerfile(tmpdir)
-        runner = CliRunner()
-        result = runner.invoke(cli, ["dev", "--version", "test"])
-        assert result.exit_code == 0
-        docker_client_mock.build.assert_called_with(
-            decode=True, path=tmpdir, tag='registry/user/project:test')
+        {"stream": "Successfully built 12345"}
+    ]
+    runner = CliRunner()
+    result = runner.invoke(cli, ["dev", "--version", "test"])
+    assert result.exit_code == 0
+    docker_client_mock.build.assert_called_with(
+        decode=True, path=project_dir, tag='registry/user/project:test')
     test_mock.assert_called_with("dev", "test")
 
 
-def test_cli_no_dockerfile(docker_client_mock):
+def test_cli_no_dockerfile(docker_client_mock, project_dir):
     docker_client_mock.build.return_value = [
         {"error": "Minor", "errorDetail": "Testing output"},
-        {"stream": "Successfully built 12345"}]
-    with FakeProjectDirectory() as tmpdir:
-        add_scrapy_fake_config(tmpdir)
-        add_sh_fake_config(tmpdir)
-        runner = CliRunner()
-        result = runner.invoke(cli, ["dev"])
-        assert result.exit_code == \
-            shub_exceptions.BadParameterException.exit_code
+        {"stream": "Successfully built 12345"}
+    ]
+    os.remove(os.path.join(project_dir, 'Dockerfile'))
+    runner = CliRunner()
+    result = runner.invoke(cli, ["dev"])
+    assert result.exit_code == shub_exceptions.BadParameterException.exit_code
 
-
+@pytest.mark.usefixtures('project_dir')
 def test_cli_fail(docker_client_mock):
     docker_client_mock.build.return_value = [
         {"error": "Minor", "errorDetail": "Test"}
     ]
-    with FakeProjectDirectory() as tmpdir:
-        add_scrapy_fake_config(tmpdir)
-        add_sh_fake_config(tmpdir)
-        add_fake_dockerfile(tmpdir)
-        runner = CliRunner()
-        result = runner.invoke(cli, ["dev"])
-        assert result.exit_code == \
-            shub_exceptions.RemoteErrorException.exit_code
+    runner = CliRunner()
+    result = runner.invoke(cli, ["dev"])
+    assert result.exit_code == shub_exceptions.RemoteErrorException.exit_code
+
+
+@pytest.mark.parametrize('skip_tests_flag', ['-S', '--skip-tests'])
+def test_cli_skip_tests(docker_client_mock, test_mock, project_dir, skip_tests_flag):
+    docker_client_mock.build.return_value = [
+        {"stream": "all is ok"},
+        {"stream": "Successfully built 12345"}
+    ]
+    setup_py_path = os.path.join(project_dir, 'setup.py')
+    assert not os.path.isfile(setup_py_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["dev", skip_tests_flag])
+    assert result.exit_code == 0
+    docker_client_mock.build.assert_called_with(
+        decode=True, path=project_dir, tag='registry/user/project:1.0')
+    assert os.path.isfile(setup_py_path)
+    assert test_mock.call_count == 0

--- a/tests/image/test_push.py
+++ b/tests/image/test_push.py
@@ -1,6 +1,4 @@
-import mock
 from click.testing import CliRunner
-from unittest import TestCase
 from shub import exceptions as shub_exceptions
 from shub.image.push import cli
 
@@ -8,107 +6,103 @@ from .utils import FakeProjectDirectory
 from .utils import add_sh_fake_config
 
 
-@mock.patch('shub.image.utils.get_docker_client')
-class TestPushCli(TestCase):
+def test_cli_with_apikey_login(docker_client_mock, test_mock):
+    docker_client_mock.login.return_value = {"Status": "Login Succeeded"}
+    docker_client_mock.push.return_value = [
+        {"stream": "In process"},
+        {"status": "Successfully pushed"}]
+    with FakeProjectDirectory() as tmpdir:
+        add_sh_fake_config(tmpdir)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["dev", "--version", "test"])
+        assert result.exit_code == 0
+        docker_client_mock.push.assert_called_with(
+            'registry/user/project:test', decode=True,
+            insecure_registry=False, stream=True)
+    test_mock.assert_called_with("dev", "test")
 
-    def test_cli_with_apikey_login(self, mocked_method):
-        mocked = mock.MagicMock()
-        mocked.login.return_value = {"Status": "Login Succeeded"}
-        mocked.push.return_value = [
-            {"stream": "In process"},
-            {"status": "Successfully pushed"}]
-        mocked_method.return_value = mocked
-        with FakeProjectDirectory() as tmpdir:
-            add_sh_fake_config(tmpdir)
-            runner = CliRunner()
-            result = runner.invoke(cli, ["dev", "--version", "test"])
-            assert result.exit_code == 0
-            mocked.push.assert_called_with(
-                'registry/user/project:test', decode=True,
-                insecure_registry=False, stream=True)
 
-    def test_cli_with_custom_login(self, mocked_method):
-        mocked = mock.MagicMock()
-        mocked.login.return_value = {"Status": "Login Succeeded"}
-        mocked.push.return_value = [
-            {"stream": "In process"},
-            {"status": "Successfully pushed"}]
-        mocked_method.return_value = mocked
-        with FakeProjectDirectory() as tmpdir:
-            add_sh_fake_config(tmpdir)
-            runner = CliRunner()
-            result = runner.invoke(
-                cli, ["dev", "--version", "test", "--username", "user",
-                      "--password", "pass", "--email", "mail"])
-            assert result.exit_code == 0
-            mocked.login.assert_called_with(
-                email=u'mail', password=u'pass',
-                reauth=False, registry='registry', username=u'user')
-            mocked.push.assert_called_with(
-                'registry/user/project:test', decode=True,
-                insecure_registry=False, stream=True)
+def test_cli_with_custom_login(docker_client_mock, test_mock):
+    docker_client_mock.login.return_value = {"Status": "Login Succeeded"}
+    docker_client_mock.push.return_value = [
+        {"stream": "In process"},
+        {"status": "Successfully pushed"}]
+    with FakeProjectDirectory() as tmpdir:
+        add_sh_fake_config(tmpdir)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["dev", "--version", "test", "--username", "user",
+                  "--password", "pass", "--email", "mail"])
+        assert result.exit_code == 0
+        docker_client_mock.login.assert_called_with(
+            email=u'mail', password=u'pass',
+            reauth=False, registry='registry', username=u'user')
+        docker_client_mock.push.assert_called_with(
+            'registry/user/project:test', decode=True,
+            insecure_registry=False, stream=True)
+    test_mock.assert_called_with("dev", "test")
 
-    def test_cli_with_insecure_registry(self, mocked_method):
-        mocked = mock.MagicMock()
-        mocked.login.return_value = {"Status": "Login Succeeded"}
-        mocked.push.return_value = [
-            {"stream": "In process"},
-            {"status": "Successfully pushed"}]
-        mocked_method.return_value = mocked
-        with FakeProjectDirectory() as tmpdir:
-            add_sh_fake_config(tmpdir)
-            runner = CliRunner()
-            result = runner.invoke(
-                cli, ["dev", "--version", "test", "--insecure"])
-            assert result.exit_code == 0
-            assert not mocked.login.called
-            mocked.push.assert_called_with(
-                'registry/user/project:test', decode=True,
-                insecure_registry=True, stream=True)
 
-    def test_cli_with_login_username_only(self, mocked_method):
-        mocked = mock.MagicMock()
-        mocked.login.return_value = {"Status": "Login Succeeded"}
-        mocked.push.return_value = [
-            {"stream": "In process"},
-            {"status": "Successfully pushed"}]
-        mocked_method.return_value = mocked
-        with FakeProjectDirectory() as tmpdir:
-            add_sh_fake_config(tmpdir)
-            runner = CliRunner()
-            result = runner.invoke(
-                cli, ["dev", "--version", "test", "--apikey", "apikey"])
-            assert result.exit_code == 0
-            mocked.login.assert_called_with(
-                email=None, password=' ',
-                reauth=False, registry='registry', username='apikey')
-            mocked.push.assert_called_with(
-                'registry/user/project:test', decode=True,
-                insecure_registry=False, stream=True)
+def test_cli_with_insecure_registry(docker_client_mock, test_mock):
+    docker_client_mock.login.return_value = {"Status": "Login Succeeded"}
+    docker_client_mock.push.return_value = [
+        {"stream": "In process"},
+        {"status": "Successfully pushed"}]
+    with FakeProjectDirectory() as tmpdir:
+        add_sh_fake_config(tmpdir)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["dev", "--version", "test", "--insecure"])
+        assert result.exit_code == 0
+        assert not docker_client_mock.login.called
+        docker_client_mock.push.assert_called_with(
+            'registry/user/project:test', decode=True,
+            insecure_registry=True, stream=True)
+    test_mock.assert_called_with("dev", "test")
 
-    def test_cli_login_fail(self, mocked_method):
-        mocked = mock.MagicMock()
-        mocked.login.return_value = {"Status": "Login Failed!"}
-        mocked_method.return_value = mocked
-        with FakeProjectDirectory() as tmpdir:
-            add_sh_fake_config(tmpdir)
-            runner = CliRunner()
-            result = runner.invoke(
-                cli, ["dev", "--version", "test", "--username", "user",
-                      "--password", "pass", "--email", "mail"])
-            assert result.exit_code == \
-                shub_exceptions.RemoteErrorException.exit_code
 
-    def test_cli_push_fail(self, mocked_method):
-        mocked = mock.MagicMock()
-        mocked.login.return_value = {"Status": "Login Succeeded"}
-        mocked.push.return_value = [{"error": "Failed:(", "errorDetail": ""}]
-        mocked_method.return_value = mocked
-        with FakeProjectDirectory() as tmpdir:
-            add_sh_fake_config(tmpdir)
-            runner = CliRunner()
-            result = runner.invoke(
-                cli, ["dev", "--version", "test", "--username", "user",
-                      "--password", "pass", "--email", "mail"])
-            assert result.exit_code == \
-                shub_exceptions.RemoteErrorException.exit_code
+def test_cli_with_login_username_only(docker_client_mock, test_mock):
+    docker_client_mock.login.return_value = {"Status": "Login Succeeded"}
+    docker_client_mock.push.return_value = [
+        {"stream": "In process"},
+        {"status": "Successfully pushed"}]
+    with FakeProjectDirectory() as tmpdir:
+        add_sh_fake_config(tmpdir)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["dev", "--version", "test", "--apikey", "apikey"])
+        assert result.exit_code == 0
+        docker_client_mock.login.assert_called_with(
+            email=None, password=' ',
+            reauth=False, registry='registry', username='apikey')
+        docker_client_mock.push.assert_called_with(
+            'registry/user/project:test', decode=True,
+            insecure_registry=False, stream=True)
+    test_mock.assert_called_with("dev", "test")
+
+
+def test_cli_login_fail(docker_client_mock, test_mock):
+    docker_client_mock.login.return_value = {"Status": "Login Failed!"}
+    with FakeProjectDirectory() as tmpdir:
+        add_sh_fake_config(tmpdir)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["dev", "--version", "test", "--username", "user",
+                  "--password", "pass", "--email", "mail"])
+        assert result.exit_code == \
+            shub_exceptions.RemoteErrorException.exit_code
+    test_mock.assert_called_with("dev", "test")
+
+
+def test_cli_push_fail(docker_client_mock, test_mock):
+    docker_client_mock.login.return_value = {"Status": "Login Succeeded"}
+    docker_client_mock.push.return_value = [{"error": "Failed:(", "errorDetail": ""}]
+    with FakeProjectDirectory() as tmpdir:
+        add_sh_fake_config(tmpdir)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["dev", "--version", "test", "--username", "user",
+                  "--password", "pass", "--email", "mail"])
+        assert result.exit_code == \
+            shub_exceptions.RemoteErrorException.exit_code
+    test_mock.assert_called_with("dev", "test")

--- a/tests/image/test_push.py
+++ b/tests/image/test_push.py
@@ -1,108 +1,119 @@
+import pytest
 from click.testing import CliRunner
 from shub import exceptions as shub_exceptions
 from shub.image.push import cli
 
-from .utils import FakeProjectDirectory
-from .utils import add_sh_fake_config
 
-
+@pytest.mark.usefixtures('project_dir')
 def test_cli_with_apikey_login(docker_client_mock, test_mock):
     docker_client_mock.login.return_value = {"Status": "Login Succeeded"}
     docker_client_mock.push.return_value = [
         {"stream": "In process"},
-        {"status": "Successfully pushed"}]
-    with FakeProjectDirectory() as tmpdir:
-        add_sh_fake_config(tmpdir)
-        runner = CliRunner()
-        result = runner.invoke(cli, ["dev", "--version", "test"])
-        assert result.exit_code == 0
-        docker_client_mock.push.assert_called_with(
-            'registry/user/project:test', decode=True,
-            insecure_registry=False, stream=True)
+        {"status": "Successfully pushed"}
+    ]
+    runner = CliRunner()
+    result = runner.invoke(cli, ["dev", "--version", "test"])
+    assert result.exit_code == 0
+    docker_client_mock.push.assert_called_with(
+        'registry/user/project:test', decode=True,
+        insecure_registry=False, stream=True)
     test_mock.assert_called_with("dev", "test")
 
 
+@pytest.mark.usefixtures('project_dir')
 def test_cli_with_custom_login(docker_client_mock, test_mock):
     docker_client_mock.login.return_value = {"Status": "Login Succeeded"}
     docker_client_mock.push.return_value = [
         {"stream": "In process"},
-        {"status": "Successfully pushed"}]
-    with FakeProjectDirectory() as tmpdir:
-        add_sh_fake_config(tmpdir)
-        runner = CliRunner()
-        result = runner.invoke(
-            cli, ["dev", "--version", "test", "--username", "user",
-                  "--password", "pass", "--email", "mail"])
-        assert result.exit_code == 0
-        docker_client_mock.login.assert_called_with(
-            email=u'mail', password=u'pass',
-            reauth=False, registry='registry', username=u'user')
-        docker_client_mock.push.assert_called_with(
-            'registry/user/project:test', decode=True,
-            insecure_registry=False, stream=True)
+        {"status": "Successfully pushed"}
+    ]
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["dev", "--version", "test", "--username", "user",
+              "--password", "pass", "--email", "mail"])
+    assert result.exit_code == 0
+    docker_client_mock.login.assert_called_with(
+        email=u'mail', password=u'pass',
+        reauth=False, registry='registry', username=u'user')
+    docker_client_mock.push.assert_called_with(
+        'registry/user/project:test', decode=True,
+        insecure_registry=False, stream=True)
     test_mock.assert_called_with("dev", "test")
 
 
+@pytest.mark.usefixtures('project_dir')
 def test_cli_with_insecure_registry(docker_client_mock, test_mock):
     docker_client_mock.login.return_value = {"Status": "Login Succeeded"}
     docker_client_mock.push.return_value = [
         {"stream": "In process"},
-        {"status": "Successfully pushed"}]
-    with FakeProjectDirectory() as tmpdir:
-        add_sh_fake_config(tmpdir)
-        runner = CliRunner()
-        result = runner.invoke(
-            cli, ["dev", "--version", "test", "--insecure"])
-        assert result.exit_code == 0
-        assert not docker_client_mock.login.called
-        docker_client_mock.push.assert_called_with(
-            'registry/user/project:test', decode=True,
-            insecure_registry=True, stream=True)
+        {"status": "Successfully pushed"}
+    ]
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["dev", "--version", "test", "--insecure"])
+    assert result.exit_code == 0
+    assert not docker_client_mock.login.called
+    docker_client_mock.push.assert_called_with(
+        'registry/user/project:test', decode=True,
+        insecure_registry=True, stream=True)
     test_mock.assert_called_with("dev", "test")
 
 
+@pytest.mark.usefixtures('project_dir')
 def test_cli_with_login_username_only(docker_client_mock, test_mock):
     docker_client_mock.login.return_value = {"Status": "Login Succeeded"}
     docker_client_mock.push.return_value = [
         {"stream": "In process"},
-        {"status": "Successfully pushed"}]
-    with FakeProjectDirectory() as tmpdir:
-        add_sh_fake_config(tmpdir)
-        runner = CliRunner()
-        result = runner.invoke(
-            cli, ["dev", "--version", "test", "--apikey", "apikey"])
-        assert result.exit_code == 0
-        docker_client_mock.login.assert_called_with(
-            email=None, password=' ',
-            reauth=False, registry='registry', username='apikey')
-        docker_client_mock.push.assert_called_with(
-            'registry/user/project:test', decode=True,
-            insecure_registry=False, stream=True)
+        {"status": "Successfully pushed"}
+    ]
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["dev", "--version", "test", "--apikey", "apikey"])
+    assert result.exit_code == 0
+    docker_client_mock.login.assert_called_with(
+        email=None, password=' ',
+        reauth=False, registry='registry', username='apikey')
+    docker_client_mock.push.assert_called_with(
+        'registry/user/project:test', decode=True,
+        insecure_registry=False, stream=True)
     test_mock.assert_called_with("dev", "test")
 
 
+@pytest.mark.usefixtures('project_dir')
 def test_cli_login_fail(docker_client_mock, test_mock):
     docker_client_mock.login.return_value = {"Status": "Login Failed!"}
-    with FakeProjectDirectory() as tmpdir:
-        add_sh_fake_config(tmpdir)
-        runner = CliRunner()
-        result = runner.invoke(
-            cli, ["dev", "--version", "test", "--username", "user",
-                  "--password", "pass", "--email", "mail"])
-        assert result.exit_code == \
-            shub_exceptions.RemoteErrorException.exit_code
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["dev", "--version", "test", "--username", "user",
+              "--password", "pass", "--email", "mail"])
+    assert result.exit_code == shub_exceptions.RemoteErrorException.exit_code
     test_mock.assert_called_with("dev", "test")
 
 
+@pytest.mark.usefixtures('project_dir')
 def test_cli_push_fail(docker_client_mock, test_mock):
     docker_client_mock.login.return_value = {"Status": "Login Succeeded"}
     docker_client_mock.push.return_value = [{"error": "Failed:(", "errorDetail": ""}]
-    with FakeProjectDirectory() as tmpdir:
-        add_sh_fake_config(tmpdir)
-        runner = CliRunner()
-        result = runner.invoke(
-            cli, ["dev", "--version", "test", "--username", "user",
-                  "--password", "pass", "--email", "mail"])
-        assert result.exit_code == \
-            shub_exceptions.RemoteErrorException.exit_code
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["dev", "--version", "test", "--username", "user",
+              "--password", "pass", "--email", "mail"])
+    assert result.exit_code == shub_exceptions.RemoteErrorException.exit_code
     test_mock.assert_called_with("dev", "test")
+
+
+@pytest.mark.usefixtures('project_dir')
+@pytest.mark.parametrize('skip_tests_flag', ['-S', '--skip-tests'])
+def test_cli_skip_tests(docker_client_mock, test_mock, skip_tests_flag):
+    docker_client_mock.login.return_value = {"Status": "Login Succeeded"}
+    docker_client_mock.push.return_value = [
+        {"stream": "In process"},
+        {"status": "Successfully pushed"}
+    ]
+    runner = CliRunner()
+    result = runner.invoke(cli, ["dev", "--version", "test", skip_tests_flag])
+    assert result.exit_code == 0
+    docker_client_mock.push.assert_called_with(
+        'registry/user/project:test', decode=True,
+        insecure_registry=False, stream=True)
+    assert test_mock.call_count == 0

--- a/tests/image/test_upload.py
+++ b/tests/image/test_upload.py
@@ -19,6 +19,6 @@ class TestUploadCli(TestCase):
         assert result.exit_code == 0
         build.assert_called_with('dev', 'test', True)
         push.assert_called_with(
-            'dev', 'test', 'user', 'pass', 'mail', "apikey", False)
+            'dev', 'test', 'user', 'pass', 'mail', "apikey", False, skip_tests=True)
         deploy.assert_called_with(
             'dev', 'test', 'user', 'pass', 'mail', "apikey", False, True)


### PR DESCRIPTION
- Test image before `shub image push`.
- Skip tests if necessary with `-S/--skip-tests`.
- In `shub image upload` command tests are running during the build.
- Update tests for build, push and upload commands.
- Migrate test cases for build and push commands from unittest.TestCase to idiomatic pytest test cases with fixtures.
- Added new tests for -S/--skip-tests flag.
- Added project_dir fixture and removed boilerplate code from build and push commands tests.