### PR TITLE
Fix shub image init

### DIFF
--- a/shub/image/init.py
+++ b/shub/image/init.py
@@ -3,7 +3,6 @@ import textwrap
 from string import Template
 
 import click
-from six.moves import input
 
 from shub import exceptions as shub_exceptions
 from shub import utils as shub_utils
@@ -11,7 +10,7 @@ from shub.image import utils
 
 
 DOCKER_APP_DIR = '/app'
-DOCKERFILE_TEMPLATE = """
+DOCKERFILE_TEMPLATE = """\
 FROM $base_image
 $system_deps
 $system_env
@@ -22,42 +21,41 @@ COPY . {docker_app_dir}
 RUN python setup.py install
 """.format(docker_app_dir=DOCKER_APP_DIR)
 
-BASE_SYSTEM_DEPS = [
-    'telnet', 'vim', 'htop', 'strace', 'ltrace', 'iputils-ping', 'lsof'
-]
 BASE_PYTHON_DEPS = [
-    'BeautifulSoup==3.2.0', 'MySQL-python==1.2.3', 'Scrapy==1.0.3',
-    'Twisted==11.1.0', 'boto==2.28.0', 'guppy==0.1.10', 'hubstorage==0.19.1',
-    'ipython==3.2.1', 'lxml==3.4.4', 'numpy==1.6.1', 'pika==0.9.14',
-    'psycopg2==2.4.5', 'pymongo==2.6.3', 'queuelib==1.2.2',
-    'raven==5.0.0', 'requests==2.5.3', 'scrapely==0.12.0',
-    'scrapinghub==1.7.0', 'scrapylib==1.6.0', 'setproctitle==1.0.1',
-    'slybot==0.12.1', 'w3lib==1.13.0',
-    'scrapinghub-entrypoint-scrapy==0.6.0'
+    'BeautifulSoup==3.2.0',
+    'MySQL-python==1.2.3',
+    'guppy==0.1.10',
+    'ipython==5.3.0',
+    'numpy==1.12.1',
+    'pika==0.10.0',
+    'psycopg2==2.7.1',
+    'pymongo==3.4.0',
+    'setproctitle==1.1.10',
+    'slybot==0.12.1',
 ]
 
-SHORT_HELP = "Form Dockerfile for a given Scrapy project and save it."
+SHORT_HELP = "Create Dockerfile for existing Scrapy project."
 
 HELP = """
-Init command creates a Dockerfile for your project. It's likely that
-default values will fit to you, otherwise you will be able to edit your
-Dockerfile as you want.
+Init command creates a Dockerfile for existing Scrapy project. This tool is for users
+who want to create a custom Docker image and don't have a Dockerfile yet. If generated
+Dockerfile doesn't fit your project feel free to edit it.
 
-System deps for Dockerfile:
-By default there're several system deps to be included to the Dockerfile ({}),
-you can extend it via --add-deps option, or redefine at all with --base-deps
-option.
+Python packages
 
-Python deps for Dockerfile:
-The correct way to install python deps is using requirements.txt. If there's
-no requirements.txt in the project_dir folder and no provided value for it
-via --requirements option, we'll create new requirements.txt in the
-project_dir with the recommended deps(use --list-recommended-reqs to list it).
+If there's a requirements.txt file in the project directory - it will be added to the
+Dockerfile. Also it's possible to provide a path to requirements file via --requirements
+option. Otherwise new requirements.txt file will be created in the project directory
+with the recommended Python packages. Use --list-recommended-reqs to list them.
 
-You should also include scrapinghub-entrypoint-scrapy package to your py-reqs,
-it's a necessary condition to run your project with Kumo (use 'shub image test'
-to check if your image fits our expectations).
-""".format(BASE_SYSTEM_DEPS)
+It's recommended to include scrapinghub-entrypoint-scrapy package - it is a
+support layer that passes data from the job to Scrapinghub storage. Otherwise
+you will need to send data to Scrapinghub storage using HTTP API.
+
+System packages
+
+You can extend list of system packages installed in the image via --add-deps option.
+"""
 
 
 def list_recommended_python_reqs(ctx, param, value):
@@ -70,18 +68,27 @@ def list_recommended_python_reqs(ctx, param, value):
     ctx.exit()
 
 
+def _deprecate_base_deps_parameter(ctx, param, value):
+    if value:
+        click.echo("WARNING: --base-deps parameter is deprecated. "
+                   "Please use --add-deps parameter instead.",
+                   err=True)
+    return value
+
+
 @click.command(help=HELP, short_help=SHORT_HELP)
 @click.option("--list-recommended-reqs", is_flag=True, is_eager=True,
               expose_value=False, callback=list_recommended_python_reqs,
               help="list recommended python requirements")
 @click.option("--project", default="default",
               help="project name to get settings module from scrapy.cfg")
-@click.option("--base-image", default="python:2.7",
+@click.option("--base-image", default="scrapinghub/scrapinghub-stack-scrapy:1.3",
               help="base docker image name")
-@click.option("--base-deps", default=','.join(BASE_SYSTEM_DEPS),
-              help="a comma-separated list with base system deps")
+@click.option("--base-deps", default='',
+              help="[DEPRECATED] a comma-separated list with base system dependencies",
+              callback=_deprecate_base_deps_parameter)
 @click.option("--add-deps",
-              help="a comma-separated list with additional system deps")
+              help="a comma-separated list with additional system dependencies")
 @click.option("--requirements", default="requirements.txt",
               help="path to requirements.txt")
 def cli(project, base_image, base_deps, add_deps, requirements):
@@ -89,7 +96,9 @@ def cli(project, base_image, base_deps, add_deps, requirements):
     scrapy_config = shub_utils.get_config()
     if not scrapy_config.has_option('settings', project):
         raise shub_exceptions.BadConfigException(
-            'Settings for the project is not found')
+            'Cannot find Scrapy project settings. Please ensure that current directory '
+            'contains scrapy.cfg with settings section, see example at '
+            'https://doc.scrapy.org/en/latest/topics/commands.html#default-structure-of-scrapy-projects')  # NOQA
     settings_module = scrapy_config.get('settings', project)
     values = {
         'base_image':   base_image,
@@ -98,23 +107,16 @@ def cli(project, base_image, base_deps, add_deps, requirements):
         'requirements': _format_requirements(project_dir, requirements),
     }
     values = {key: value if value else '' for key, value in values.items()}
-    source = Template(DOCKERFILE_TEMPLATE.strip())
+    source = Template(DOCKERFILE_TEMPLATE)
     results = source.substitute(values)
     results = results.replace('\n\n', '\n')
 
     click.echo("The following Dockerfile will be created:\n{}".format(results))
-    valid = {"yes": True, "y": True, "ye": True,
-             "no": False, "n": False}
-    while True:
-        dockefile_path = os.path.join(project_dir, 'Dockerfile')
-        choice = input("Save to {}: (y/n)".format(dockefile_path)).lower()
-        if choice in valid:
-            if valid[choice]:
-                with open(dockefile_path, 'w') as dockerfile:
-                    dockerfile.write(results)
-                click.echo('Saved.')
-            break
-        click.echo("Please respond with 'yes'('y') or 'no'(n)")
+    dockefile_path = os.path.join(project_dir, 'Dockerfile')
+    if click.confirm("Save to {}?".format(dockefile_path)):
+        with open(dockefile_path, 'w') as dockerfile:
+            dockerfile.write(results)
+        click.echo('Saved.')
 
 
 def _format_system_deps(base_deps, add_deps):
@@ -123,11 +125,11 @@ def _format_system_deps(base_deps, add_deps):
     if add_deps:
         system_add_deps = add_deps.split(',')
         system_deps = list(set(system_deps + system_add_deps))
+    system_deps = sorted(filter(None, system_deps))
     if not system_deps:
         return
-    deps_string = ' '.join(sorted(system_deps))
     commands = ["apt-get update -qq",
-                "apt-get install -qy {}".format(deps_string),
+                "apt-get install -qy {}".format(' '.join(system_deps)),
                 "rm -rf /var/lib/apt/lists/*"]
     return 'RUN ' + ' && \\\n    '.join(
         [_wrap(cmd) for cmd in commands])

--- a/shub/image/init.py
+++ b/shub/image/init.py
@@ -22,17 +22,8 @@ RUN python setup.py install
 """.format(docker_app_dir=DOCKER_APP_DIR)
 
 DEFAULT_BASE_IMAGE = "scrapinghub/scrapinghub-stack-scrapy:1.3"
-BASE_PYTHON_DEPS = [
-    'BeautifulSoup==3.2.0',
-    'MySQL-python==1.2.3',
+RECOMMENDED_PYTHON_DEPS = [
     'guppy==0.1.10',
-    'ipython==5.3.0',
-    'numpy==1.12.1',
-    'pika==0.10.0',
-    'psycopg2==2.7.1',
-    'pymongo==3.4.0',
-    'setproctitle==1.1.10',
-    'slybot==0.12.1',
 ]
 
 SHORT_HELP = "Create Dockerfile for existing Scrapy project."
@@ -64,7 +55,7 @@ def list_recommended_python_reqs(ctx, param, value):
     if not value:
         return
     click.echo("Recommended Python deps list:")
-    for dep in BASE_PYTHON_DEPS:
+    for dep in RECOMMENDED_PYTHON_DEPS:
         click.echo('- {}'.format(dep))
     ctx.exit()
 
@@ -162,7 +153,7 @@ def _format_requirements(project_dir, requirements):
     else:
         # let's create requirements.txt with base dependencies
         with open(rel_reqs_path, 'w') as reqs_file:
-            reqs_file.writelines("%s\n" % l for l in BASE_PYTHON_DEPS)
+            reqs_file.writelines("%s\n" % l for l in RECOMMENDED_PYTHON_DEPS)
         click.echo('Created base requirements.txt in project dir.')
     rows = [
         'COPY ./{} {}/requirements.txt'.format(rel_reqs_path, DOCKER_APP_DIR),

--- a/shub/utils.py
+++ b/shub/utils.py
@@ -413,7 +413,9 @@ def get_sources(use_closest=True):
                xdg_config_home + '/scrapy.cfg',
                os.path.expanduser('~/.scrapy.cfg')]
     if use_closest:
-        sources.append(closest_file('scrapy.cfg'))
+        closest_scrapy_cfg_path = closest_file('scrapy.cfg')
+        if closest_scrapy_cfg_path:
+            sources.append(closest_scrapy_cfg_path)
     return sources
 
 

--- a/tests/image/test_init.py
+++ b/tests/image/test_init.py
@@ -1,6 +1,7 @@
 import os
+
+import pytest
 from click.testing import CliRunner
-from unittest import TestCase
 
 from shub.exceptions import BadConfigException
 from shub.image.init import cli
@@ -9,10 +10,7 @@ from shub.image.init import _format_system_env
 from shub.image.init import _format_requirements
 from shub.image.init import _wrap
 
-from .utils import FakeProjectDirectory
 from .utils import add_fake_requirements
-from .utils import add_sh_fake_config
-from .utils import add_scrapy_fake_config
 
 
 BASE_DOCKERFILE = """\
@@ -28,99 +26,102 @@ RUN python setup.py install
 """
 
 
-class TestInitCli(TestCase):
+@pytest.fixture
+def project_dir(project_dir):
+    """Overriden project_dir fixture without Dockerfile"""
+    dockerfile_path = os.path.join(project_dir, 'Dockerfile')
+    os.remove(dockerfile_path)
+    return project_dir
 
-    def test_cli_default_settings(self):
-        with FakeProjectDirectory() as tmpdir:
-            add_scrapy_fake_config(tmpdir)
-            add_sh_fake_config(tmpdir)
-            runner = CliRunner()
-            result = runner.invoke(cli, [], input='no\n')
-            assert result.exit_code == 0
-            assert BASE_DOCKERFILE in result.output
-            assert not os.path.exists(os.path.join(tmpdir, 'Dockerfile'))
 
-    def test_cli_list_recommended_reqs(self):
-        with FakeProjectDirectory() as tmpdir:
-            add_scrapy_fake_config(tmpdir)
-            add_sh_fake_config(tmpdir)
-            runner = CliRunner()
-            result = runner.invoke(cli, ["--list-recommended-reqs"])
-            assert result.exit_code == 0
-            assert "Recommended Python deps list:" in result.output
+def test_cli_default_settings(project_dir):
+    runner = CliRunner()
+    result = runner.invoke(cli, [], input='no\n')
+    assert result.exit_code == 0
+    assert BASE_DOCKERFILE in result.output
+    assert not os.path.exists(os.path.join(project_dir, 'Dockerfile'))
 
-    def test_cli_store_dockerfile(self):
-        with FakeProjectDirectory() as tmpdir:
-            add_scrapy_fake_config(tmpdir)
-            add_sh_fake_config(tmpdir)
-            runner = CliRunner()
-            result = runner.invoke(cli, [], input='yes\n')
-            assert result.exit_code == 0
-            assert BASE_DOCKERFILE in result.output
-            assert os.path.exists(os.path.join(tmpdir, 'Dockerfile'))
 
-    def test_wrap(self):
-        short_cmd = "run short command wrapping another one short"
-        assert _wrap(short_cmd) == short_cmd
-        assert _wrap(short_cmd + ' ' + short_cmd) == (
-            short_cmd + ' ' + ' '.join(short_cmd.split()[:3]) +
-            " \\\n    " + ' '.join(short_cmd.split()[3:]))
+@pytest.mark.usefixtures('project_dir')
+def test_cli_list_recommended_reqs():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--list-recommended-reqs"])
+    assert result.exit_code == 0
+    assert "Recommended Python deps list:" in result.output
 
-    def test_format_system_deps(self):
-        # no deps at all
-        assert _format_system_deps('-', None) is None
-        # base deps only
-        assert _format_system_deps('a,b,cd', None) == (
-            "RUN apt-get update -qq && \\\n"
-            "    apt-get install -qy a b cd && \\\n"
-            "    rm -rf /var/lib/apt/lists/*")
-        # base & additional deps only
-        assert _format_system_deps('a,b,cd', 'ef,hk,b') == (
-            "RUN apt-get update -qq && \\\n"
-            "    apt-get install -qy a b cd ef hk && \\\n"
-            "    rm -rf /var/lib/apt/lists/*")
-        # additional deps only
-        assert _format_system_deps('-', 'ef,hk,b') == (
-            "RUN apt-get update -qq && \\\n"
-            "    apt-get install -qy b ef hk && \\\n"
-            "    rm -rf /var/lib/apt/lists/*")
 
-    def test_format_system_env(self):
-        assert _format_system_env(None) == 'ENV TERM xterm'
-        assert _format_system_env('test.settings') == (
-            "ENV TERM xterm\n"
-            "ENV SCRAPY_SETTINGS_MODULE test.settings")
+def test_cli_store_dockerfile(project_dir):
+    runner = CliRunner()
+    result = runner.invoke(cli, [], input='yes\n')
+    assert result.exit_code == 0
+    assert BASE_DOCKERFILE in result.output
+    assert os.path.exists(os.path.join(project_dir, 'Dockerfile'))
 
-    def test_format_requirements(self):
-        with FakeProjectDirectory() as tmpdir:
-            add_fake_requirements(tmpdir)
-            basereqs = os.path.join(tmpdir, 'requirements.txt')
-            if os.path.exists(basereqs):
-                os.remove(basereqs)
-            # use given requirements
-            assert _format_requirements(
-                os.getcwd(), 'fake-requirements.txt') == (
-                    "COPY ./fake-requirements.txt /app/requirements.txt\n"
-                    "RUN pip install --no-cache-dir -r requirements.txt")
-            assert not os.path.exists(basereqs)
-            # using base requirements
-            assert _format_requirements(
-                os.getcwd(), 'requirements.txt') == (
-                    "COPY ./requirements.txt /app/requirements.txt\n"
-                    "RUN pip install --no-cache-dir -r requirements.txt")
-            assert os.path.exists(basereqs)
-            os.remove(basereqs)
 
-    def test_no_scrapy_cfg(self):
-        with FakeProjectDirectory() as tmpdir:
-            add_sh_fake_config(tmpdir)
-            runner = CliRunner()
-            result = runner.invoke(cli, [])
-            assert result.exit_code == BadConfigException.exit_code
-            error_msg = (
-                'Error: Cannot find Scrapy project settings. Please ensure that current '
-                'directory contains scrapy.cfg with settings section, see example at '
-                'https://doc.scrapy.org/en/latest/topics/commands.html#default-structure-of-scrapy-projects'
-            )
-            assert error_msg in result.output
-            assert not os.path.exists(os.path.join(tmpdir, 'Dockerfile'))
+def test_wrap():
+    short_cmd = "run short command wrapping another one short"
+    assert _wrap(short_cmd) == short_cmd
+    assert _wrap(short_cmd + ' ' + short_cmd) == (
+        short_cmd + ' ' + ' '.join(short_cmd.split()[:3]) +
+        " \\\n    " + ' '.join(short_cmd.split()[3:]))
+
+
+def test_format_system_deps():
+    # no deps at all
+    assert _format_system_deps('-', None) is None
+    # base deps only
+    assert _format_system_deps('a,b,cd', None) == (
+        "RUN apt-get update -qq && \\\n"
+        "    apt-get install -qy a b cd && \\\n"
+        "    rm -rf /var/lib/apt/lists/*")
+    # base & additional deps only
+    assert _format_system_deps('a,b,cd', 'ef,hk,b') == (
+        "RUN apt-get update -qq && \\\n"
+        "    apt-get install -qy a b cd ef hk && \\\n"
+        "    rm -rf /var/lib/apt/lists/*")
+    # additional deps only
+    assert _format_system_deps('-', 'ef,hk,b') == (
+        "RUN apt-get update -qq && \\\n"
+        "    apt-get install -qy b ef hk && \\\n"
+        "    rm -rf /var/lib/apt/lists/*")
+
+
+def test_format_system_env():
+    assert _format_system_env(None) == 'ENV TERM xterm'
+    assert _format_system_env('test.settings') == (
+        "ENV TERM xterm\n"
+        "ENV SCRAPY_SETTINGS_MODULE test.settings")
+
+
+def test_format_requirements(project_dir):
+    add_fake_requirements(project_dir)
+    basereqs = os.path.join(project_dir, 'requirements.txt')
+    if os.path.exists(basereqs):
+        os.remove(basereqs)
+    # use given requirements
+    assert _format_requirements(
+        os.getcwd(), 'fake-requirements.txt') == (
+            "COPY ./fake-requirements.txt /app/requirements.txt\n"
+            "RUN pip install --no-cache-dir -r requirements.txt")
+    assert not os.path.exists(basereqs)
+    # using base requirements
+    assert _format_requirements(
+        os.getcwd(), 'requirements.txt') == (
+            "COPY ./requirements.txt /app/requirements.txt\n"
+            "RUN pip install --no-cache-dir -r requirements.txt")
+    assert os.path.exists(basereqs)
+    os.remove(basereqs)
+
+
+def test_no_scrapy_cfg(project_dir):
+    os.remove(os.path.join(project_dir, 'scrapy.cfg'))
+    runner = CliRunner()
+    result = runner.invoke(cli, [])
+    assert result.exit_code == BadConfigException.exit_code
+    error_msg = (
+        'Error: Cannot find Scrapy project settings. Please ensure that current '
+        'directory contains scrapy.cfg with settings section, see example at '
+        'https://doc.scrapy.org/en/latest/topics/commands.html#default-structure-of-scrapy-projects'
+    )
+    assert error_msg in result.output
+    assert not os.path.exists(os.path.join(project_dir, 'Dockerfile'))


### PR DESCRIPTION
It failed with TypeError if there was not scrapy.cfg in the current directory.

Update help message and error message.
Update base image in Dockerfile template.
Update list of recommended Python packages.
Use click.confirm to prompt for save file confirmation.
Deprecate --base-deps parameter.
Update init command tests.