### PR TITLE
Shub image push progress with tqdm

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -4,5 +4,6 @@ PyYAML
 requests
 retrying
 six
+tqdm
 
 scrapinghub>=1.9.0

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         'requests',
         'scrapinghub>=1.9.0',
         'six>=1.7.0',
+        'tqdm',
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/shub/image/utils.py
+++ b/shub/image/utils.py
@@ -4,6 +4,7 @@ import click
 import contextlib
 
 import yaml
+from tqdm import tqdm
 
 from shub import config as shub_config
 from shub import utils as shub_utils
@@ -207,3 +208,11 @@ def valid_spiders(buf):
     ['A77aque']
     """
     return sorted(filter(_VALIDSPIDERNAME.match, buf.splitlines()))
+
+
+class ProgressBar(tqdm):
+
+    def moveto(self, *args, **kwargs):
+        super(ProgressBar, self).moveto(*args, **kwargs)
+        if hasattr(self.fp, 'flush'):
+            self.fp.flush()


### PR DESCRIPTION
The goal of the changes is to improve verbosity of push progress, cause events stream in verbose mode is too verbose and hard to read, and non-verbose mode is silent and can wait for a lot of time w/o any sign of life, especially when there're a lot of layers to push and network is flaky.

Initial attempt was to achieve similar results with built-in [click.progressbar](http://click.pocoo.org/5/api/#click.progressbar), but there're a few issues with it:
- it doesn't support multiple bars and it's tricky to work it around
- single bar works fine, but we don't have any variable to track total progress with enough details - only as amount of layers left to push (but if some layers are large it doesn't work good)
- almost always several layers are being pushed at the same time, and it's hard to represent its progress properly

As a result, I wasn't satisfied with built-in `click.progressbar` possibilities and decided to try [tqdm](https://github.com/tqdm/tqdm) library as it's much more flexible, provides multiple bars out-of-the-box and pretty configurable (also it's pretty lightweight and should work fine everywhere).

The proposed workflow also brings light on some complexities related with handling docker-push events stream:
- it's not straightforward to estimate amount of layers to push - `docker inspect` is closest approach, but it works differently on different platform and thus not very reliable (on OSX layers are in `RootFS->Layers`, and on Linux layers are not showed this way)
- we don't know size of pushed layer in advance because docker compresses it before sending

Please, review. // cc @chekunkov 