### PR TITLE
Create setup.py on shub image init

### DIFF
--- a/shub/image/init.py
+++ b/shub/image/init.py
@@ -94,7 +94,8 @@ def cli(project, base_image, base_deps, add_deps, requirements):
     dockefile_path = os.path.join(project_dir, 'Dockerfile')
     if os.path.exists(dockefile_path):
         raise shub_exceptions.ShubException('Found a Dockerfile in the project directory, aborting')
-    settings_module = scrapy_config.get('settings', project)
+    settings_module = scrapy_config.get('settings', 'default')
+    shub_utils.create_default_setup_py(settings=settings_module)
     values = {
         'base_image':   base_image,
         'system_deps':  _format_system_deps(base_deps, add_deps),

--- a/shub/image/utils.py
+++ b/shub/image/utils.py
@@ -1,7 +1,6 @@
 import os
 import re
 import click
-import contextlib
 
 import yaml
 from tqdm import tqdm
@@ -43,15 +42,6 @@ def deprecate_debug_parameter(ctx, param, value):
         click.echo("WARNING: -d/--debug parameter is deprecated. "
                    "Please use -v/--verbose parameter instead.",
                    err=True)
-
-
-@contextlib.contextmanager
-def remember_cwd():
-    current_dir = os.getcwd()
-    try:
-        yield
-    finally:
-        os.chdir(current_dir)
 
 
 def get_project_dir():

--- a/tests/image/conftest.py
+++ b/tests/image/conftest.py
@@ -4,8 +4,9 @@ import pytest
 
 from .utils import (
     FakeProjectDirectory, add_scrapy_fake_config, add_sh_fake_config,
-    add_fake_dockerfile
+    add_fake_dockerfile, add_fake_setup_py,
 )
+
 
 @pytest.fixture
 def docker_client_mock():
@@ -23,4 +24,5 @@ def project_dir():
         add_scrapy_fake_config(tmpdir)
         add_sh_fake_config(tmpdir)
         add_fake_dockerfile(tmpdir)
+        add_fake_setup_py(tmpdir)
         yield tmpdir

--- a/tests/image/test_build.py
+++ b/tests/image/test_build.py
@@ -19,14 +19,11 @@ def test_cli(docker_client_mock, project_dir, test_mock):
         {"stream": "all is ok"},
         {"stream": "Successfully built 12345"}
     ]
-    setup_py_path = os.path.join(project_dir, 'setup.py')
-    assert not os.path.isfile(setup_py_path)
     runner = CliRunner()
     result = runner.invoke(cli, ["dev", "-v"])
     assert result.exit_code == 0
     docker_client_mock.build.assert_called_with(
         decode=True, path=project_dir, tag='registry/user/project:1.0')
-    assert os.path.isfile(setup_py_path)
     test_mock.assert_called_with("dev", None)
 
 
@@ -53,6 +50,7 @@ def test_cli_no_dockerfile(docker_client_mock, project_dir):
     result = runner.invoke(cli, ["dev"])
     assert result.exit_code == shub_exceptions.BadParameterException.exit_code
 
+
 @pytest.mark.usefixtures('project_dir')
 def test_cli_fail(docker_client_mock):
     docker_client_mock.build.return_value = [
@@ -69,12 +67,9 @@ def test_cli_skip_tests(docker_client_mock, test_mock, project_dir, skip_tests_f
         {"stream": "all is ok"},
         {"stream": "Successfully built 12345"}
     ]
-    setup_py_path = os.path.join(project_dir, 'setup.py')
-    assert not os.path.isfile(setup_py_path)
     runner = CliRunner()
     result = runner.invoke(cli, ["dev", skip_tests_flag])
     assert result.exit_code == 0
     docker_client_mock.build.assert_called_with(
         decode=True, path=project_dir, tag='registry/user/project:1.0')
-    assert os.path.isfile(setup_py_path)
     assert test_mock.call_count == 0

--- a/tests/image/test_init.py
+++ b/tests/image/test_init.py
@@ -16,8 +16,7 @@ from .utils import add_fake_requirements
 @pytest.fixture
 def project_dir(project_dir):
     """Overriden project_dir fixture without Dockerfile"""
-    dockerfile_path = os.path.join(project_dir, 'Dockerfile')
-    os.remove(dockerfile_path)
+    os.remove(os.path.join(project_dir, 'Dockerfile'))
     return project_dir
 
 
@@ -50,6 +49,15 @@ def test_cli_abort_if_dockerfile_exists(project_dir):
     assert os.path.exists(os.path.join(project_dir, 'Dockerfile'))
     with open(dockerfile_path) as f:
         assert f.read() == ''
+
+
+def test_cli_create_setup_py(project_dir):
+    setup_py_path = os.path.join(project_dir, 'setup.py')
+    os.remove(setup_py_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, [], input='yes\n')
+    assert result.exit_code == 0
+    assert os.path.isfile(setup_py_path)
 
 
 def test_wrap():


### PR DESCRIPTION
It makes more sense to create `setup.py` if it doesn't exist on `init` step instead of `build`.

Review, please.