### PR TITLE
Add "Create scrapinghub.yml" wizard to shub image build

### DIFF
--- a/freeze/tests/run.py
+++ b/freeze/tests/run.py
@@ -48,7 +48,7 @@ def test_version():
 def test_deploy_without_project():
     stdout, stderr = shub('deploy').communicate()
     assert stdout == b''
-    assert b'Error: No Scrapy project found in this location.' in stderr
+    assert b'Cannot find project' in stderr
 
 
 def test_deploy_default_project(apipipe, scrapyproject):

--- a/shub/config.py
+++ b/shub/config.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-import contextlib
 import netrc
 import os
 import warnings
@@ -14,7 +13,8 @@ from shub.exceptions import (BadParameterException, BadConfigException,
                              NotFoundException, ShubDeprecationWarning,
                              print_warning)
 from shub.utils import (closest_file, get_scrapycfg_targets, get_sources,
-                        pwd_hg_version, pwd_git_version, pwd_version)
+                        pwd_hg_version, pwd_git_version, pwd_version,
+                        update_yaml_dict)
 
 
 SH_IMAGES_REGISTRY = 'images.scrapinghub.com'
@@ -403,7 +403,7 @@ def _migrate_to_global_scrapinghub_yml():
         netrc_key = None
     if netrc_key:
         conf.apikeys['default'] = netrc_key
-    conf.save()
+    conf.save(GLOBAL_SCRAPINGHUB_YML_PATH)
     default_conf = ShubConfig()
     migrated_data = any(getattr(conf, attr) != getattr(default_conf, attr)
                         for attr in ('projects', 'endpoints', 'apikeys',
@@ -472,32 +472,6 @@ def load_shub_config(load_global=True, load_local=True, load_env=True):
         else:
             _migrate_and_load_scrapy_cfg(conf)
     return conf
-
-
-@contextlib.contextmanager
-def update_yaml_dict(conf_path=None):
-    """
-    Context manager for updating a YAML file. Key ordering and comments are not
-    preserved.
-    """
-    conf_path = conf_path or GLOBAL_SCRAPINGHUB_YML_PATH
-    try:
-        with open(conf_path, 'r') as f:
-            conf = yaml.safe_load(f) or {}
-    except IOError as e:
-        if e.errno != 2:
-            raise
-        conf = {}
-    # Code inside context manager is executed after this yield
-    yield conf
-    # Avoid writing "key: {}"
-    for key in list(conf.keys()):
-        if conf[key] == {}:
-            del conf[key]
-    with open(conf_path, 'w') as f:
-        # Avoid writing "{}"
-        if conf:
-            yaml.dump(conf, f, default_flow_style=False)
 
 
 def get_target(target, auth_required=True):

--- a/shub/config.py
+++ b/shub/config.py
@@ -165,7 +165,7 @@ class ShubConfig(object):
             self._load_scrapycfg_target(tname, t)
         self._check_endpoints()
 
-    def save(self, path=None):
+    def save(self, path=None, options=None):
         def _project_id_as_int(project):
             """Copy project and return it with the ID casted to int to make
             sure it is exported as "123" and not "'123'"
@@ -184,7 +184,9 @@ class ShubConfig(object):
             return project
 
         with update_yaml_dict(path) as yml:
-            for option, shortcut in self.SHORTCUTS.items():
+            options = options or list(self.SHORTCUTS)
+            for option in options:
+                shortcut = self.SHORTCUTS[option]
                 conf = getattr(self, option)
                 if option == 'endpoints' and conf == ShubConfig().endpoints:
                     # Don't write default endpoint

--- a/shub/deploy.py
+++ b/shub/deploy.py
@@ -111,8 +111,6 @@ def _call_wizard(conf):
 
 def deploy_cmd(target, version, debug, egg, build_egg, verbose, keep_log,
                conf=None):
-    if not inside_project():
-        raise NotFoundException("No Scrapy project found in this location.")
     tmpdir = None
     try:
         if build_egg:
@@ -182,6 +180,8 @@ def _upload_egg(endpoint, eggpath, project, version, auth, verbose, keep_log,
 
 
 def _build_egg():
+    if not inside_project():
+        raise NotFoundException("No Scrapy project found in this location.")
     settings = get_config().get('settings', 'default')
     create_default_setup_py(settings=settings)
     d = tempfile.mkdtemp(prefix="shub-deploy-")

--- a/shub/deploy.py
+++ b/shub/deploy.py
@@ -20,14 +20,14 @@ else:
 
 from scrapinghub import Connection, APIError
 
-from shub.config import (load_shub_config, update_yaml_dict,
-                         list_targets_callback, SH_IMAGES_REGISTRY)
+from shub.config import (list_targets_callback, load_shub_config,
+                         SH_IMAGES_REGISTRY)
 from shub.exceptions import (InvalidAuthException, NotFoundException,
                              RemoteErrorException, ShubException,
                              BadParameterException)
-from shub.utils import (closest_file, get_config, inside_project,
-                        make_deploy_request, run_python,
-                        create_default_setup_py)
+from shub.utils import (closest_file, create_default_setup_py, get_config,
+                        inside_project, make_deploy_request, run_python,
+                        update_yaml_dict)
 from shub.image.upload import upload_cmd
 
 

--- a/shub/deploy.py
+++ b/shub/deploy.py
@@ -22,8 +22,8 @@ from shub.config import (list_targets_callback, load_shub_config,
 from shub.exceptions import (BadParameterException, NotFoundException,
                              ShubException)
 from shub.utils import (create_default_setup_py, create_scrapinghub_yml_wizard,
-                        get_config, inside_project, make_deploy_request,
-                        run_python)
+                        get_config, get_project_dir, inside_project,
+                        make_deploy_request, run_python)
 from shub.image.upload import upload_cmd
 
 
@@ -71,10 +71,13 @@ SHORT_HELP = "Deploy Scrapy project to Scrapy Cloud"
 @click.option("-k", "--keep-log", help="keep the deploy log", is_flag=True)
 def cli(target, version, debug, egg, build_egg, verbose, keep_log):
     conf, image = load_shub_config(), None
+    if not build_egg and target == 'default' and target not in conf.projects:
+        _call_wizard(conf)
     if target in conf.projects:
         image = conf.get_target_conf(target).image
     if not image:
-        deploy_cmd(target, version, debug, egg, build_egg, verbose, keep_log)
+        deploy_cmd(target, version, debug, egg, build_egg, verbose, keep_log,
+                   conf=conf)
     elif image.startswith(SH_IMAGES_REGISTRY):
         upload_cmd(target, version)
     else:
@@ -83,7 +86,31 @@ def cli(target, version, debug, egg, build_egg, verbose, keep_log):
             "other than Scrapinghub default registry.")
 
 
-def deploy_cmd(target, version, debug, egg, build_egg, verbose, keep_log):
+def _call_wizard(conf):
+    """Call the onboarding wizard, figuring out if we should ask about image
+    configuration based on the existence of a Dockerfile.
+
+    If there is a scrapy.cfg and a Dockerfile, ask if it should be deployed as
+    custom image. If there is a Dockerfile but no scrapy.cfg, always assume it
+    should be deployed as custom image.
+    """
+    image_wizard = False
+    project_dir = get_project_dir()
+    has_scrapy_cfg = os.path.isfile(os.path.join(project_dir, 'scrapy.cfg'))
+    has_dockerfile = os.path.isfile(os.path.join(project_dir, 'Dockerfile'))
+    if has_scrapy_cfg and has_dockerfile:
+        image_wizard = click.confirm(
+            "You have a Dockerfile in your project directory. Would "
+            "you like to deploy it as custom image?", default=True)
+    elif has_dockerfile:
+        image_wizard = True
+    else:
+        image_wizard = False
+    create_scrapinghub_yml_wizard(conf, image=image_wizard)
+
+
+def deploy_cmd(target, version, debug, egg, build_egg, verbose, keep_log,
+               conf=None):
     if not inside_project():
         raise NotFoundException("No Scrapy project found in this location.")
     tmpdir = None
@@ -93,9 +120,7 @@ def deploy_cmd(target, version, debug, egg, build_egg, verbose, keep_log):
             click.echo("Writing egg to %s" % build_egg)
             shutil.copyfile(egg, build_egg)
         else:
-            conf = load_shub_config()
-            if target == 'default' and target not in conf.projects:
-                create_scrapinghub_yml_wizard(conf)
+            conf = conf or load_shub_config()
             targetconf = conf.get_target_conf(target)
             version = version or targetconf.version
             auth = (targetconf.apikey, '')

--- a/shub/image/build.py
+++ b/shub/image/build.py
@@ -7,6 +7,7 @@ from shub import exceptions as shub_exceptions
 from shub.config import load_shub_config, list_targets_callback
 from shub.image import utils
 from shub.image.test import test_cmd
+from shub.utils import create_scrapinghub_yml_wizard
 
 
 SHORT_HELP = 'Build release image.'
@@ -43,9 +44,13 @@ def cli(target, debug, verbose, version, skip_tests):
 
 
 def build_cmd(target, version, skip_tests):
+    config = load_shub_config()
+    image_configured = (
+        target in config.projects and config.get_target_conf(target).image)
+    if not target.isdigit() and not image_configured:
+        create_scrapinghub_yml_wizard(config, target=target, image=True)
     client = utils.get_docker_client()
     project_dir = utils.get_project_dir()
-    config = load_shub_config()
     image = config.get_image(target)
     image_name = utils.format_image_name(image, version)
     if not os.path.exists(os.path.join(project_dir, 'Dockerfile')):

--- a/shub/image/init.py
+++ b/shub/image/init.py
@@ -6,7 +6,6 @@ import click
 
 from shub import exceptions as shub_exceptions
 from shub import utils as shub_utils
-from shub.image import utils
 
 
 DOCKER_APP_DIR = '/app'
@@ -84,13 +83,14 @@ def _deprecate_base_deps_parameter(ctx, param, value):
 @click.option("--requirements", default="requirements.txt",
               help="path to requirements.txt")
 def cli(project, base_image, base_deps, add_deps, requirements):
-    project_dir = utils.get_project_dir()
+    closest_scrapy_cfg = shub_utils.closest_file('scrapy.cfg')
     scrapy_config = shub_utils.get_config()
-    if not scrapy_config.has_option('settings', project):
+    if not closest_scrapy_cfg or not scrapy_config.has_option('settings', project):
         raise shub_exceptions.BadConfigException(
             'Cannot find Scrapy project settings. Please ensure that current directory '
             'contains scrapy.cfg with settings section, see example at '
             'https://doc.scrapy.org/en/latest/topics/commands.html#default-structure-of-scrapy-projects')  # NOQA
+    project_dir = os.path.dirname(closest_scrapy_cfg)
     dockefile_path = os.path.join(project_dir, 'Dockerfile')
     if os.path.exists(dockefile_path):
         raise shub_exceptions.ShubException('Found a Dockerfile in the project directory, aborting')

--- a/shub/login.py
+++ b/shub/login.py
@@ -4,8 +4,10 @@ import requests
 from six.moves import input
 from six.moves.urllib.parse import urljoin
 
-from shub.config import load_shub_config, ShubConfig, update_yaml_dict
+from shub.config import (load_shub_config, GLOBAL_SCRAPINGHUB_YML_PATH,
+                         ShubConfig)
 from shub.exceptions import AlreadyLoggedInException
+from shub.utils import update_yaml_dict
 
 
 HELP = """
@@ -31,7 +33,7 @@ def cli():
         suggestion=conf.apikeys.get('default'),
         endpoint=global_conf.endpoints.get('default'),
     )
-    with update_yaml_dict() as conf:
+    with update_yaml_dict(GLOBAL_SCRAPINGHUB_YML_PATH) as conf:
         conf.setdefault('apikeys', {})
         conf['apikeys']['default'] = key
 

--- a/shub/logout.py
+++ b/shub/logout.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import
 import click
 
-from shub.config import load_shub_config, update_yaml_dict
+from shub.config import load_shub_config, GLOBAL_SCRAPINGHUB_YML_PATH
+from shub.utils import update_yaml_dict
 
 
 HELP = """
@@ -19,5 +20,5 @@ def cli():
         click.echo("You are not logged in.")
         return 0
 
-    with update_yaml_dict() as conf:
+    with update_yaml_dict(GLOBAL_SCRAPINGHUB_YML_PATH) as conf:
         del conf['apikeys']['default']

--- a/shub/utils.py
+++ b/shub/utils.py
@@ -652,15 +652,25 @@ def has_project_access(project, endpoint, apikey):
             raise RemoteErrorException(str(e))
 
 
+def get_project_dir():
+    """Get the path to the closest directory that contains either
+    ``scrapinghub.yml``. ``scrapy.cfg``, or ``Dockerfile`` (in this priority).
+    """
+    for filename in ['scrapinghub.yml', 'scrapy.cfg', 'Dockerfile']:
+        closest = closest_file(filename)
+        if closest:
+            return os.path.dirname(closest)
+    raise NotFoundException(
+        "Cannot find project: There is no scrapinghub.yml, scrapy.cfg, or "
+        "Dockerfile in this directory or any of the parent directories.")
+
+
 def create_scrapinghub_yml_wizard(conf, target='default'):
     """
     Ask user for project ID, ensure they have access to that project, and save
     it to given ``target`` in local ``scrapinghub.yml`` if desired.
     """
-    closest_scrapycfg = closest_file('scrapy.cfg')
-    sh_yml_dir = (os.path.dirname(closest_scrapycfg) if closest_scrapycfg
-                  else os.getcwd())
-    closest_sh_yml = os.path.join(sh_yml_dir, 'scrapinghub.yml')
+    closest_sh_yml = os.path.join(get_project_dir(), 'scrapinghub.yml')
     # Get default endpoint and API key (meanwhile making sure the user is
     # logged in)
     endpoint, apikey = conf.get_endpoint(0), conf.get_apikey(0)

--- a/shub/utils.py
+++ b/shub/utils.py
@@ -635,7 +635,7 @@ def update_yaml_dict(conf_path=None):
     with open(conf_path, 'w') as f:
         # Avoid writing "{}"
         if conf:
-            yaml.dump(conf, f, default_flow_style=False)
+            yaml.safe_dump(conf, f, default_flow_style=False)
 
 
 def has_project_access(project, endpoint, apikey):

--- a/tests/image/test_build.py
+++ b/tests/image/test_build.py
@@ -17,6 +17,14 @@ def test_mock():
         yield m
 
 
+@pytest.fixture
+def wizard_mock():
+    """Mock for shub.utils.create_scrapinghub_yml_wizard"""
+    with mock.patch('shub.utils.create_scrapinghub_yml_wizard') as m,\
+            mock.patch('shub.utils.has_project_access', return_value=True):
+        yield m
+
+
 def test_cli(docker_client_mock, project_dir, test_mock):
     docker_client_mock.build.return_value = [
         {"stream": "all is ok"},
@@ -97,3 +105,21 @@ def test_cli_skip_tests(docker_client_mock, test_mock, project_dir, skip_tests_f
     docker_client_mock.build.assert_called_with(
         decode=True, path=project_dir, tag='registry/user/project:1.0')
     assert test_mock.call_count == 0
+
+
+@pytest.mark.usefixtures('wizard_mock')
+@pytest.mark.usefixtures('test_mock')
+def test_cli_calls_onboarding_wizard(docker_client_mock, project_dir):
+    with open(os.path.join(project_dir, 'scrapinghub.yml'), 'w') as f:
+        f.write('apikey: abcdef')
+    docker_client_mock.build.return_value = [
+        {"stream": "all is ok"},
+        {"stream": "Successfully built 12345"}
+    ]
+    runner = CliRunner()
+    result = runner.invoke(cli, ['12345'])
+    assert result.exit_code == shub_exceptions.NotFoundException.exit_code
+    result = runner.invoke(cli, input='12345\nmyregistry/X/Y\n')
+    assert result.exit_code == 0
+    docker_client_mock.build.assert_called_with(
+        decode=True, path=project_dir, tag='myregistry/X/Y:1.0')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -429,6 +429,29 @@ class ShubConfigTest(unittest.TestCase):
             # Make sure it is readable again
             ShubConfig().load_file('scrapinghub.yml')
 
+    def test_save_partial_options(self):
+        OLD_YML = """\
+        projects:
+            default: 12345
+            prod: 33333
+        stack: custom-stack
+        """
+        with CliRunner().isolated_filesystem():
+            with open('conf.yml', 'w') as f:
+                f.write(textwrap.dedent(OLD_YML))
+            conf = ShubConfig()
+            conf.load_file('conf.yml')
+            del conf.projects['prod']
+            del conf.stacks['default']
+            conf.save('conf.yml', options=['projects'])
+            with open('conf.yml', 'r') as f:
+                self.assertEqual(
+                    yaml.load(f),
+                    {'project': 12345, 'stack': 'custom-stack'})
+            conf.save('conf.yml')
+            with open('conf.yml', 'r') as f:
+                self.assertEqual(yaml.load(f), {'project': 12345})
+
     def test_normalized_projects(self):
         expected_projects = {
             'shproj': _project_dict(123),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,7 +13,7 @@ from click.testing import CliRunner
 
 from shub.config import (get_target, get_target_conf, get_version,
                          load_shub_config, ShubConfig, Target,
-                         update_yaml_dict, SH_IMAGES_REPOSITORY)
+                         SH_IMAGES_REPOSITORY)
 from shub.exceptions import (BadParameterException, BadConfigException,
                              ConfigParseException, MissingAuthException,
                              NotFoundException)
@@ -807,30 +807,6 @@ class LoadShubConfigTest(unittest.TestCase):
 
 
 class ConfigHelpersTest(unittest.TestCase):
-
-    def test_update_yaml_dict(self):
-        YAML_BEFORE = textwrap.dedent("""\
-            a:
-              unrelated: dict
-            b:
-              key1: val1
-              key2: val2
-        """)
-        DICT_EXPECTED = {
-            'a': {'unrelated': 'dict'},
-            'b': {'key1': 'newval1', 'key2': 'val2', 'key3': 'val3'}
-        }
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            with open('conf.yml', 'w') as f:
-                f.write(YAML_BEFORE)
-            with update_yaml_dict('conf.yml') as conf:
-                conf['b']['key1'] = 'newval1'
-                conf['b']['key3'] = 'val3'
-            with open('conf.yml', 'r') as f:
-                self.assertEqual(yaml.safe_load(f), DICT_EXPECTED)
-                f.seek(0)
-                self.assertIn("key1: newval1", f.read())
 
     @mock.patch('shub.config.load_shub_config')
     def test_get_target_version(self, mock_lsh):

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -117,6 +117,9 @@ class DeployTest(AssertInvokeRaisesMixin, unittest.TestCase):
             self.runner.invoke(deploy.cli)
             self.assertFalse(mock_wizard.called)
             del self.conf.projects['default']
+            self.runner.invoke(deploy.cli)
+            self.assertTrue(mock_wizard.called)
+            mock_wizard.reset_mock()
             # Don't call when non-default target was supplied
             self.runner.invoke(deploy.cli, 'not-default')
             self.assertFalse(mock_wizard.called)

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -80,38 +80,17 @@ class DeployTest(AssertInvokeRaisesMixin, unittest.TestCase):
             assert result.exit_code == 0
 
     @patch('shub.deploy.make_deploy_request')
-    @patch('shub.deploy._has_project_access')
-    def test_deploy_wizard(self, mock_project_access, mock_deploy_req):
+    @patch('shub.deploy.create_scrapinghub_yml_wizard')
+    def test_calls_scrapinghub_yml_wizard(self, mock_wizard, mock_deploy_req):
         with self.runner.isolated_filesystem():
             self._make_project()
-            with patch('shub.deploy._deploy_wizard') as mock_wizard:
-                # Don't call when 'default' defined in the global conf
-                self.runner.invoke(deploy.cli)
-                self.assertFalse(mock_wizard.called)
-                del self.conf.projects['default']
-                # Don't call when non-default target was supplied
-                self.runner.invoke(deploy.cli, 'not-default')
-                self.assertFalse(mock_wizard.called)
-            # Wizard is live from here on
-            mock_project_access.return_value = False
-            self.assertInvokeRaises(InvalidAuthException, deploy.cli,
-                                    input='99\nn\n')
-            # Don't create scrapinghub.yml if not wished
-            mock_project_access.return_value = True
-            self.runner.invoke(deploy.cli, input='99\nn\n')
-            self.assertEqual(self.conf.projects['default'], 99)
-            self.assertFalse(os.path.exists('scrapinghub.yml'))
-            # Create scrapinghub.yml if wished
+            # Don't call when 'default' defined in the global conf
+            self.runner.invoke(deploy.cli)
+            self.assertFalse(mock_wizard.called)
             del self.conf.projects['default']
-            self.runner.invoke(deploy.cli, input='199\n\n')
-            self.assertEqual(self.conf.projects['default'], 199)
-            self.assertTrue(os.path.exists('scrapinghub.yml'))
-            # Also run wizard when there's a scrapinghub.yml but no default
-            # target
-            del self.conf.projects['default']
-            self.conf.projects['prod'] = 299
-            self.runner.invoke(deploy.cli, input='399\n\n')
-            self.assertEqual(self.conf.projects['default'], 399)
+            # Don't call when non-default target was supplied
+            self.runner.invoke(deploy.cli, 'not-default')
+            self.assertFalse(mock_wizard.called)
 
     @patch('shub.deploy.deploy_cmd')
     def test_custom_deploy_disabled(self, mock_deploy_cmd):

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -35,8 +35,7 @@ class ShubEndToEndTests(unittest.TestCase):
     def test_deploy_isnt_broken(self):
         output = self.run_subcmd('deploy')
         error = 'Unexpected output: %s' % output
-        self.assertTrue('No Scrapy project found in this location' in output,
-                        error)
+        self.assertTrue('Cannot find project' in output, error)
 
     def test_fetch_eggs_isnt_broken(self):
         output = self.run_subcmd('fetch-eggs')

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -15,6 +15,7 @@ from .utils import AssertInvokeRaisesMixin
 VALID_KEY = 32 * '1'
 
 
+@patch('shub.login.GLOBAL_SCRAPINGHUB_YML_PATH', new='.scrapinghub.yml')
 @patch('shub.config.GLOBAL_SCRAPINGHUB_YML_PATH', new='.scrapinghub.yml')
 @patch('shub.config.NETRC_PATH', new='.netrc')
 @patch('shub.config.get_sources', new=MagicMock(return_value=[]))

--- a/tests/test_logout.py
+++ b/tests/test_logout.py
@@ -10,6 +10,7 @@ from shub import config, logout
 
 @mock.patch('shub.config.GLOBAL_SCRAPINGHUB_YML_PATH', new='.scrapinghub.yml')
 @mock.patch('shub.config.NETRC_PATH', new='.netrc')
+@mock.patch('shub.logout.GLOBAL_SCRAPINGHUB_YML_PATH', new='.scrapinghub.yml')
 class LogoutTestCase(unittest.TestCase):
 
     def setUp(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,7 +8,10 @@ import os
 import stat
 import sys
 import unittest
+import textwrap
 import time
+
+import yaml
 
 from mock import Mock, MagicMock, patch
 from click.testing import CliRunner
@@ -406,6 +409,30 @@ class UtilsTest(unittest.TestCase):
                                   rsp=rsp, verbose=True)
         self.assertEqual(last_logs, [
             b"line1", b'{"status":"ok","fieldK":"fieldV"}'])
+
+    def test_update_yaml_dict(self):
+        YAML_BEFORE = textwrap.dedent("""\
+            a:
+              unrelated: dict
+            b:
+              key1: val1
+              key2: val2
+        """)
+        DICT_EXPECTED = {
+            'a': {'unrelated': 'dict'},
+            'b': {'key1': 'newval1', 'key2': 'val2', 'key3': 'val3'}
+        }
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            with open('conf.yml', 'w') as f:
+                f.write(YAML_BEFORE)
+            with utils.update_yaml_dict('conf.yml') as conf:
+                conf['b']['key1'] = 'newval1'
+                conf['b']['key3'] = 'val3'
+            with open('conf.yml', 'r') as f:
+                self.assertEqual(yaml.safe_load(f), DICT_EXPECTED)
+                f.seek(0)
+                self.assertIn("key1: newval1", f.read())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Move `update_yaml_dict` from `shub.config` into `shub.utils`
* Move onboarding wizard from `shub.deploy` into `shub.utils`
* In `shub image init`, don't look for `scrapinghub.yml`, but for `scrapy.cfg`
* Extend the onboarding wizard so that it also asks for a Docker registry (if called from a `shub image` command)
* In `shub image build`, call the onboarding wizard if we can't find a `scrapinghub.yml`, or can't find a Docker registry in it