### PR TITLE
Shub deploy improvements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,16 +4,15 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
-
 backports.ssl-match-hostname==3.5.0.1  # via docker-py
 click==6.6
 docker-py==1.10.6
 docker-pycreds==0.2.1     # via docker-py
-hubstorage==0.23.1
 ipaddress==1.0.17         # via docker-py
-PyYAML==3.12
+pyyaml==3.12
 requests==2.10.0
 retrying==1.3.3
 scrapinghub==1.9.0
 six==1.10.0
+tqdm==4.11.2
 websocket-client==0.37.0  # via docker-py

--- a/shub/deploy.py
+++ b/shub/deploy.py
@@ -188,7 +188,10 @@ def _deploy_wizard(conf, target='default'):
     closest_scrapycfg = closest_file('scrapy.cfg')
     # Double-checking to make deploy_wizard() independent of cli()
     if not closest_scrapycfg:
-        raise NotFoundException("No Scrapy project found in this location.")
+        raise NotFoundException(
+            "Cannot deploy project: failed to find Scrapy project and "
+            "custom images are not configured in scrapinghub.yml."
+        )
     closest_sh_yml = os.path.join(os.path.dirname(closest_scrapycfg),
                                   'scrapinghub.yml')
     # Get default endpoint and API key (meanwhile making sure the user is

--- a/shub/deploy.py
+++ b/shub/deploy.py
@@ -21,7 +21,7 @@ else:
 from scrapinghub import Connection, APIError
 
 from shub.config import (load_shub_config, update_yaml_dict,
-                         list_targets_callback, SH_IMAGES_PREFIX)
+                         list_targets_callback, SH_IMAGES_REGISTRY)
 from shub.exceptions import (InvalidAuthException, NotFoundException,
                              RemoteErrorException, ShubException,
                              BadParameterException)
@@ -79,11 +79,12 @@ def cli(target, version, debug, egg, build_egg, verbose, keep_log):
         image = conf.get_target_conf(target).image
     if not image:
         deploy_cmd(target, version, debug, egg, build_egg, verbose, keep_log)
-    elif image.startswith(SH_IMAGES_PREFIX):
+    elif image.startswith(SH_IMAGES_REGISTRY):
         upload_cmd(target, version)
     else:
-        raise BadParameterException("Please use `shub image` commands to work"
-                                    " with custom Docker registries.")
+        raise BadParameterException(
+            "Please use `shub image` commands to work with Docker registries "
+            "other than Scrapinghub default registry.")
 
 
 def deploy_cmd(target, version, debug, egg, build_egg, verbose, keep_log):

--- a/shub/deploy.py
+++ b/shub/deploy.py
@@ -62,9 +62,9 @@ SHORT_HELP = "Deploy Scrapy project to Scrapy Cloud"
 
 @click.command(help=HELP, short_help=SHORT_HELP)
 @click.argument("target", required=False, default="default")
-@click.option("-l", "--list-targets", help="list available targets",
-              is_flag=True, is_eager=True, expose_value=False,
-              callback=list_targets_callback)
+@click.option("-l", "--list-targets", is_flag=True, is_eager=True,
+              expose_value=False, callback=list_targets_callback,
+              help="List available project names defined in your config")
 @click.option("-V", "--version", help="the version to use for deploying")
 @click.option("-d", "--debug", help="debug mode (do not remove build dir)",
               is_flag=True)

--- a/shub/image/build.py
+++ b/shub/image/build.py
@@ -29,9 +29,9 @@ BUILD_SUCCESS_REGEX = re.compile(r'Successfully built ([0-9a-f]+)')
 
 @click.command(help=HELP, short_help=SHORT_HELP)
 @click.argument("target", required=False, default="default")
-@click.option("-l", "--list-targets", help="list available targets",
-              is_flag=True, is_eager=True, expose_value=False,
-              callback=list_targets_callback)
+@click.option("-l", "--list-targets", is_flag=True, is_eager=True,
+              expose_value=False, callback=list_targets_callback,
+              help="List available project names defined in your config")
 @click.option("-d", "--debug", help="debug mode", is_flag=True,
               callback=utils.deprecate_debug_parameter)
 @click.option("-v", "--verbose", is_flag=True,

--- a/shub/image/build.py
+++ b/shub/image/build.py
@@ -4,8 +4,7 @@ import re
 import click
 
 from shub import exceptions as shub_exceptions
-from shub.config import load_shub_config
-from shub.deploy import list_targets
+from shub.config import load_shub_config, list_targets_callback
 from shub.image import utils
 from shub.image.test import test_cmd
 
@@ -32,7 +31,7 @@ BUILD_SUCCESS_REGEX = re.compile(r'Successfully built ([0-9a-f]+)')
 @click.argument("target", required=False, default="default")
 @click.option("-l", "--list-targets", help="list available targets",
               is_flag=True, is_eager=True, expose_value=False,
-              callback=list_targets)
+              callback=list_targets_callback)
 @click.option("-d", "--debug", help="debug mode", is_flag=True,
               callback=utils.deprecate_debug_parameter)
 @click.option("-v", "--verbose", is_flag=True,

--- a/shub/image/deploy.py
+++ b/shub/image/deploy.py
@@ -41,9 +41,9 @@ Does a simple POST request to Dash API with given parameters
 
 @click.command(help=HELP, short_help=SHORT_HELP)
 @click.argument("target", required=False, default="default")
-@click.option("-l", "--list-targets", help="list available targets",
-              is_flag=True, is_eager=True, expose_value=False,
-              callback=list_targets_callback)
+@click.option("-l", "--list-targets", is_flag=True, is_eager=True,
+              expose_value=False, callback=list_targets_callback,
+              help="List available project names defined in your config")
 @click.option("-d", "--debug", help="debug mode", is_flag=True,
               callback=utils.deprecate_debug_parameter)
 @click.option("-v", "--verbose", is_flag=True,

--- a/shub/image/deploy.py
+++ b/shub/image/deploy.py
@@ -10,8 +10,7 @@ import requests
 from retrying import retry
 from six.moves.urllib.parse import urljoin
 
-from shub.config import load_shub_config
-from shub.deploy import list_targets
+from shub.config import load_shub_config, list_targets_callback
 from shub.exceptions import ShubException
 from shub.image import utils
 from shub.image import list as list_mod
@@ -44,7 +43,7 @@ Does a simple POST request to Dash API with given parameters
 @click.argument("target", required=False, default="default")
 @click.option("-l", "--list-targets", help="list available targets",
               is_flag=True, is_eager=True, expose_value=False,
-              callback=list_targets)
+              callback=list_targets_callback)
 @click.option("-d", "--debug", help="debug mode", is_flag=True,
               callback=utils.deprecate_debug_parameter)
 @click.option("-v", "--verbose", is_flag=True,

--- a/shub/image/list.py
+++ b/shub/image/list.py
@@ -6,8 +6,7 @@ from six import binary_type
 from six.moves.urllib.parse import urljoin
 
 from shub import exceptions as shub_exceptions
-from shub.config import load_shub_config
-from shub.deploy import list_targets
+from shub.config import load_shub_config, list_targets_callback
 from shub.image import utils
 
 
@@ -36,7 +35,7 @@ shub utils itself).
 @click.argument("target", required=False, default="default")
 @click.option("-l", "--list-targets", help="list available targets",
               is_flag=True, is_eager=True, expose_value=False,
-              callback=list_targets)
+              callback=list_targets_callback)
 @click.option("-d", "--debug", help="debug mode", is_flag=True,
               callback=utils.deprecate_debug_parameter)
 @click.option("-v", "--verbose", is_flag=True, help="stream logs to console")
@@ -52,31 +51,17 @@ def list_cmd_full(target, silent, version):
     image = config.get_image(target)
     version = version or config.get_version()
     image_name = utils.format_image_name(image, version)
-    project, endpoint, apikey = None, None, None
-    try:
-        target_conf = config.get_target_conf(target)
-    except shub_exceptions.BadParameterException as exc:
-        if 'Could not find target' not in exc.message:
-            raise
-        if not silent:
-            click.echo(
-                "Not found project for target {}, "
-                "not getting project settings from Dash.".format(target))
-    else:
-        project = target_conf.project_id
-        endpoint = target_conf.endpoint
-        apikey = target_conf.apikey
-    spiders = list_cmd(image_name, project, endpoint, apikey)
-    for spider in spiders:
+    target_conf = config.get_target_conf(target)
+    for spider in list_cmd(image_name,
+                           target_conf.project_id,
+                           target_conf.endpoint,
+                           target_conf.apikey):
         click.echo(spider)
 
 
 def list_cmd(image_name, project, endpoint, apikey):
     """Short version of list cmd to use with deploy cmd."""
-
-    settings = {}
-    if project:
-        settings = _get_project_settings(project, endpoint, apikey)
+    settings = _get_project_settings(project, endpoint, apikey)
 
     # Run a local docker container to run list-spiders cmd
     status_code, logs = _run_list_cmd(project, image_name, settings)

--- a/shub/image/list.py
+++ b/shub/image/list.py
@@ -33,9 +33,9 @@ shub utils itself).
 
 @click.command(help=HELP, short_help=SHORT_HELP)
 @click.argument("target", required=False, default="default")
-@click.option("-l", "--list-targets", help="list available targets",
-              is_flag=True, is_eager=True, expose_value=False,
-              callback=list_targets_callback)
+@click.option("-l", "--list-targets", is_flag=True, is_eager=True,
+              expose_value=False, callback=list_targets_callback,
+              help="List available project names defined in your config")
 @click.option("-d", "--debug", help="debug mode", is_flag=True,
               callback=utils.deprecate_debug_parameter)
 @click.option("-v", "--verbose", is_flag=True, help="stream logs to console")

--- a/shub/image/push.py
+++ b/shub/image/push.py
@@ -3,8 +3,7 @@ from collections import OrderedDict
 import click
 
 from shub import exceptions as shub_exceptions
-from shub.config import load_shub_config
-from shub.deploy import list_targets
+from shub.config import load_shub_config, list_targets_callback
 from shub.image import utils
 from shub.image.test import test_cmd
 
@@ -27,7 +26,7 @@ otherwise you have to enter your credentials (at least username/password).
 @click.argument("target", required=False, default="default")
 @click.option("-l", "--list-targets", help="list available targets",
               is_flag=True, is_eager=True, expose_value=False,
-              callback=list_targets)
+              callback=list_targets_callback)
 @click.option("-d", "--debug", help="debug mode", is_flag=True,
               callback=utils.deprecate_debug_parameter)
 @click.option("-v", "--verbose", is_flag=True,

--- a/shub/image/push.py
+++ b/shub/image/push.py
@@ -24,9 +24,9 @@ otherwise you have to enter your credentials (at least username/password).
 
 @click.command(help=HELP, short_help=SHORT_HELP)
 @click.argument("target", required=False, default="default")
-@click.option("-l", "--list-targets", help="list available targets",
-              is_flag=True, is_eager=True, expose_value=False,
-              callback=list_targets_callback)
+@click.option("-l", "--list-targets", is_flag=True, is_eager=True,
+              expose_value=False, callback=list_targets_callback,
+              help="List available project names defined in your config")
 @click.option("-d", "--debug", help="debug mode", is_flag=True,
               callback=utils.deprecate_debug_parameter)
 @click.option("-v", "--verbose", is_flag=True,

--- a/shub/image/test.py
+++ b/shub/image/test.py
@@ -30,9 +30,9 @@ CONTRACT_CMD_NOT_FOUND_WARNING = (
 
 @click.command(help=HELP, short_help=SHORT_HELP)
 @click.argument("target", required=False, default="default")
-@click.option("-l", "--list-targets", help="list available targets",
-              is_flag=True, is_eager=True, expose_value=False,
-              callback=list_targets_callback)
+@click.option("-l", "--list-targets", is_flag=True, is_eager=True,
+              expose_value=False, callback=list_targets_callback,
+              help="List available project names defined in your config")
 @click.option("-d", "--debug", help="debug mode", is_flag=True,
               callback=utils.deprecate_debug_parameter)
 @click.option("-v", "--verbose", is_flag=True,

--- a/shub/image/test.py
+++ b/shub/image/test.py
@@ -1,8 +1,7 @@
 import click
-from shub.deploy import list_targets
 
 from shub import exceptions as shub_exceptions
-from shub.config import load_shub_config
+from shub.config import load_shub_config, list_targets_callback
 from shub.image import utils
 
 SHORT_HELP = "Test a built image with Scrapy Cloud contract"
@@ -33,7 +32,7 @@ CONTRACT_CMD_NOT_FOUND_WARNING = (
 @click.argument("target", required=False, default="default")
 @click.option("-l", "--list-targets", help="list available targets",
               is_flag=True, is_eager=True, expose_value=False,
-              callback=list_targets)
+              callback=list_targets_callback)
 @click.option("-d", "--debug", help="debug mode", is_flag=True,
               callback=utils.deprecate_debug_parameter)
 @click.option("-v", "--verbose", is_flag=True,

--- a/shub/image/upload.py
+++ b/shub/image/upload.py
@@ -1,6 +1,6 @@
 import click
 
-from shub.deploy import list_targets
+from shub.config import list_targets_callback
 from shub.image import build
 from shub.image import push
 from shub.image import deploy
@@ -20,7 +20,7 @@ Obviously it accepts all the options for the commands above.
 @click.argument("target", required=False, default="default")
 @click.option("-l", "--list-targets", help="list available targets",
               is_flag=True, is_eager=True, expose_value=False,
-              callback=list_targets)
+              callback=list_targets_callback)
 @click.option("-d", "--debug", help="debug mode", is_flag=True,
               callback=utils.deprecate_debug_parameter)
 @click.option("-v", "--verbose", is_flag=True,
@@ -35,6 +35,12 @@ Obviously it accepts all the options for the commands above.
 @click.option("-S", "--skip-tests", help="skip testing image", is_flag=True)
 def cli(target, debug, verbose, version, username, password, email,
         apikey, insecure, async, skip_tests):
+    upload_cmd(target, version, username, password, email, apikey, insecure,
+               async, skip_tests)
+
+
+def upload_cmd(target, version, username=None, password=None, email=None,
+               apikey=None, insecure=False, async=False, skip_tests=False):
     build.build_cmd(target, version, skip_tests)
     # skip tests for push command anyway because they run in build command if not skipped
     push.push_cmd(target, version, username, password, email, apikey,

--- a/shub/image/upload.py
+++ b/shub/image/upload.py
@@ -18,9 +18,9 @@ Obviously it accepts all the options for the commands above.
 
 @click.command(help=HELP, short_help=SHORT_HELP)
 @click.argument("target", required=False, default="default")
-@click.option("-l", "--list-targets", help="list available targets",
-              is_flag=True, is_eager=True, expose_value=False,
-              callback=list_targets_callback)
+@click.option("-l", "--list-targets", is_flag=True, is_eager=True,
+              expose_value=False, callback=list_targets_callback,
+              help="List available project names defined in your config")
 @click.option("-d", "--debug", help="debug mode", is_flag=True,
               callback=utils.deprecate_debug_parameter)
 @click.option("-v", "--verbose", is_flag=True,

--- a/tests/image/test_list.py
+++ b/tests/image/test_list.py
@@ -14,25 +14,8 @@ class TestListCli(TestCase):
     def test_cli_no_sh_config(self):
         runner = CliRunner()
         result = runner.invoke(cli, ["dev", "-v", "--version", "test"])
-        assert result.exit_code == 69
-        assert 'Could not find image for dev' in result.output
-
-    @mock.patch('shub.image.utils.get_docker_client')
-    @mock.patch('requests.get')
-    def test_cli_no_project(self, get_mocked, get_client_mock):
-        client_mock = mock.Mock()
-        client_mock.create_container.return_value = {'Id': '1234'}
-        client_mock.wait.return_value = 0
-        client_mock.logs.return_value = b'abc\ndef'
-        get_client_mock.return_value = client_mock
-
-        with FakeProjectDirectory() as tmpdir:
-            add_sh_fake_config(tmpdir)
-            runner = CliRunner()
-            result = runner.invoke(cli, ["xyz", "--version", "test"])
-            assert result.exit_code == 0
-            assert result.output.endswith('abc\ndef\n')
-        assert not get_mocked.called
+        assert result.exit_code == 64
+        assert 'Could not find target "dev"' in result.output
 
     @mock.patch('shub.image.utils.get_docker_client')
     @mock.patch('requests.get')

--- a/tests/image/utils.py
+++ b/tests/image/utils.py
@@ -6,10 +6,12 @@ from contextlib import contextmanager
 
 SH_CONFIG_FILE = """
 projects:
-  dev: 12345
-images:
-  dev: registry/user/project
-  xyz: registry/xyz/project
+  dev:
+    id: 12345
+    image: registry/user/project
+  xyz:
+    id: 32167
+    image: images.scrapinghub.com/project/32167
 endpoints:
   dev: https://dash-fake
 apikeys:

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import
 import unittest
 import os
 
+import pytest
 from click.testing import CliRunner
 from mock import patch
 
@@ -71,6 +72,12 @@ class DeployTest(AssertInvokeRaisesMixin, unittest.TestCase):
         self.assertIn(self.conf.endpoints['vagrant'], url)
         self.assertEqual(data, {'project': 456, 'version': 'version'})
         self.assertEqual(auth, (self.conf.apikeys['vagrant'], ''))
+
+    def test_deploy_list_targets(self):
+        with self.runner.isolated_filesystem():
+            self._make_project()
+            result = self.runner.invoke(deploy.cli, ('--list-targets',))
+            assert result.exit_code == 0
 
     @patch('shub.deploy.make_deploy_request')
     @patch('shub.deploy._has_project_access')

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -11,7 +11,7 @@ from mock import patch
 
 from shub import deploy
 from shub.exceptions import InvalidAuthException, NotFoundException, \
-    ShubException
+    ShubException, BadParameterException
 
 from .utils import AssertInvokeRaisesMixin, mock_conf
 
@@ -105,6 +105,25 @@ class DeployTest(AssertInvokeRaisesMixin, unittest.TestCase):
             self.conf.projects['prod'] = 299
             self.runner.invoke(deploy.cli, input='399\n\n')
             self.assertEqual(self.conf.projects['default'], 399)
+
+    @patch('shub.deploy.deploy_cmd')
+    def test_custom_deploy_disabled(self, mock_deploy_cmd):
+        with self.runner.isolated_filesystem():
+            self._make_project()
+            self.runner.invoke(deploy.cli, ('custom1',))
+        self.assertTrue(mock_deploy_cmd.called)
+
+    @patch('shub.deploy.upload_cmd')
+    def test_custom_deploy_default(self, mock_upload_cmd):
+        with self.runner.isolated_filesystem():
+            self._make_project()
+            self.runner.invoke(deploy.cli, ('custom2',))
+        self.assertEqual(mock_upload_cmd.call_args[0], ('custom2', None))
+
+    def test_custom_deploy_bad_registry(self):
+        with self.runner.isolated_filesystem():
+            self._make_project()
+            self.assertInvokeRaises(BadParameterException, deploy.cli, ('custom3',))
 
 
 class DeployFilesTest(unittest.TestCase):

--- a/tests/test_migrate_eggs.py
+++ b/tests/test_migrate_eggs.py
@@ -46,6 +46,7 @@ class MigrateEggsTest(unittest.TestCase):
             endpoint='endpoint1',
             apikey='apikey1',
             stack='',
+            image='',
             requirements_file='',
             version='',
             eggs=[],

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -30,6 +30,9 @@ def mock_conf(testcase, target=None, attr=None, conf=None):
             'default': 1,
             'prod': 2,
             'vagrant': 'vagrant/3',
+            'custom1': {'id': 4, 'image': False},
+            'custom2': {'id': 5, 'image': True},
+            'custom3': {'id': 6, 'image': 'custom/image'},
         })
         conf.endpoints.update({
             'vagrant': 'https://vagrant_ep/api/',


### PR DESCRIPTION
The goal of the PR is to improve logic of `shub deploy` to provide the following things:
- [x] modify shub config logic to process `image` per project
- [x] mark `images` section as deprecated and prefer `image` setting if defined
- [x] make `images.scrapinghub.com` a default registry and use SH apikey for it as an auth
- [x] use `shub image upload` instead of `shub deploy` when there's `image` defined for the project