### PR TITLE
Fix saving configuration shortcuts after update

### DIFF
--- a/shub/config.py
+++ b/shub/config.py
@@ -168,8 +168,10 @@ class ShubConfig(object):
                     conf = {k: _project_id_as_int(v) for k, v in conf.items()}
                 if list(conf.keys()) == ['default']:
                     yml[shortcut] = conf['default']
+                    yml.pop(option, None)
                 else:
                     yml[option] = conf
+                    yml.pop(shortcut, None)
             if self.version != 'AUTO':
                 yml['version'] = self.version
             if self.eggs:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -392,6 +392,43 @@ class ShubConfigTest(unittest.TestCase):
             with open('conf.yml', 'r') as f:
                 self.assertEqual(yaml.load(f), expected_yml_dict)
 
+    def test_save_shortcut_updated(self):
+        OLD_YML = """\
+        projects:
+            default: 12345
+            prod: 33333
+        """
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            with open('scrapinghub.yml', 'w') as f:
+                f.write(textwrap.dedent(OLD_YML))
+            conf = ShubConfig()
+            conf.load_file('scrapinghub.yml')
+            del conf.projects['prod']
+            print(conf.projects)
+            conf.save('scrapinghub.yml')
+            with open('scrapinghub.yml', 'r') as f:
+                new_yml = yaml.safe_load(f)
+            # Should not contain 'projects'
+            self.assertEqual(new_yml, {'project': 12345})
+
+            conf = ShubConfig()
+            conf.load_file('scrapinghub.yml')
+            # Should also work in reverse
+            conf.projects['prod'] = 33333
+            conf.save('scrapinghub.yml')
+            with open('scrapinghub.yml', 'r') as f:
+                new_yml = yaml.safe_load(f)
+            # Should not contain 'project' singleton
+            self.assertEqual(
+                new_yml,
+                {'projects': {'default': 12345, 'prod': 33333}},
+            )
+
+            # Make sure it is readable again
+            ShubConfig().load_file('scrapinghub.yml')
+
+
     def test_normalized_projects(self):
         expected_projects = {
             'shproj': _project_dict(123),


### PR DESCRIPTION
Fixes a bug in #244 by removing existing "plural" dictionaries containing only a `default` when we write the singleton configuration.

Before this, if we had an existing `scrapinghub.yml`:

```
projects:
  default: 12345
```

and then loaded and saved from this file:

```python
In [1]: from shub.config import ShubConfig

In [2]: conf = ShubConfig()

In [3]: conf.load_file('scrapinghub.yml')

In [4]: conf.save('scrapinghub.yml')
```

the new `scrapinghub.yml` would contain both the singleton and the plural directives:

```
project: 12345
projects:
  default: 12345
```

so that it was invalid:

```python
In [5]: ShubConfig().load_file('scrapinghub.yml')

BadConfigException: You cannot specify both 'project' and a 'default' key for 'projects' in the same file
```