### PR TITLE
Push progress bars - improve handling of push events

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -62,7 +62,7 @@ def _is_tqdm_in_ascii_mode():
 def format_expected_progress(progress):
     """Replace unicode symbols in progress string for tqdm in ascii mode."""
     if _is_tqdm_in_ascii_mode():
-        to_replace = {'█': '#', '▎': '3', '▋': '6'}
+        to_replace = {'█': '#', '▏': '2', '▎': '3', '▌': '5', '▋': '6'}
         for sym in to_replace:
             progress = progress.replace(sym, to_replace[sym])
     return progress


### PR DESCRIPTION
For events without total progress take current as total.
For events with current progress greater than total - update total for the bar.

Fixes this:

<img width="1429" alt="push_empty_layer" src="https://cloud.githubusercontent.com/assets/744331/24973462/bad1bf04-1fb6-11e7-8fa1-28768cb6afd2.png">
