### PR TITLE
Refactor onboarding wizard

### DIFF
--- a/shub/image/build.py
+++ b/shub/image/build.py
@@ -45,10 +45,7 @@ def cli(target, debug, verbose, version, skip_tests):
 
 def build_cmd(target, version, skip_tests):
     config = load_shub_config()
-    image_configured = (
-        target in config.projects and config.get_target_conf(target).image)
-    if not target.isdigit() and not image_configured:
-        create_scrapinghub_yml_wizard(config, target=target, image=True)
+    create_scrapinghub_yml_wizard(config, target=target, image=True)
     client = utils.get_docker_client()
     project_dir = utils.get_project_dir()
     image = config.get_image(target)


### PR DESCRIPTION
When there's no `scrapinghub.yml`, `shub deploy 108106` will now no longer try to deploy to 108106 as Scrapy project (or fail with "No Scrapy project found"), but:

* if there is a `scrapy.cfg` and no `Dockerfile`, save 108106 as default target and deploy as Scrapy project
* if there is a `Dockerfile` and no `scrapy.cfg`, save 108106 as default target, ask for image repository, and deploy as custom image
* ask whether to use custom image if there are both `Dockerfile` and `scrapy.cfg`

The wizard will never touch any configuration if there already is a `default` target defined in `scrapinghub.yml`.

`shub image upload 108106` behaves similarly, but will always deploy as custom image project.

Closes #263 