### PR TITLE
Fail on ambiguous image configuration

### DIFF
--- a/shub/config.py
+++ b/shub/config.py
@@ -353,6 +353,12 @@ class ShubConfig(object):
             raise BadConfigException(
                 "Using custom images is disabled for the project '{}'. "
                 "Please enable it in your scrapinghub.yml.".format(target))
+        elif target_conf.stack:
+            raise BadConfigException(
+                "Ambiguous configuration: There is both a custom image and a "
+                "stack configured for project '{}'. Please see {} for "
+                "information on how to configure both custom image-based and "
+                "stack-based projects.".format(target, CONFIG_DOCS_LINK))
         default_image = SH_IMAGES_REPOSITORY.format(project=project)
         if image.startswith(SH_IMAGES_REGISTRY) and image != default_image:
             raise BadConfigException(

--- a/shub/config.py
+++ b/shub/config.py
@@ -115,7 +115,7 @@ class ShubConfig(object):
         # fail if `projects` section has keys not found in `images`
         if (check_default_image_scope and
                 not set(self.projects).issubset(set(self.images))):
-            raise BadParameterException(
+            raise BadConfigException(
                     "Found ambigious configuration: default image has global "
                     "scope now, but some projects were not using custom "
                     "images and can be broken now. Please fix your config by "
@@ -350,12 +350,12 @@ class ShubConfig(object):
                 "Could not find image for project '{}'. Please define it "
                 "in your scrapinghub.yml.".format(target))
         elif image is False:
-            raise BadParameterException(
+            raise BadConfigException(
                 "Using custom images is disabled for the project '{}'. "
                 "Please enable it in your scrapinghub.yml.".format(target))
         default_image = SH_IMAGES_REPOSITORY.format(project=project)
         if image.startswith(SH_IMAGES_REGISTRY) and image != default_image:
-            raise BadParameterException(
+            raise BadConfigException(
                 "Found wrong SH repository for project '{}': expected {}.\n  "
                 "Please use aliases `True` or `scrapinghub` to fix it in your "
                 "config.".format(target, default_image))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -496,7 +496,7 @@ class ShubConfigTest(unittest.TestCase):
         """)
         self.assertEqual(self.conf.get_image('default'),
                          SH_IMAGES_REPOSITORY.format(project=123))
-        with self.assertRaises(BadParameterException):
+        with self.assertRaises(BadConfigException):
             self.conf.get_image('stacks-explicit')
         # check that aliases work as expected
         self.assertEqual(self.conf.get_image('devel'),
@@ -527,15 +527,15 @@ class ShubConfigTest(unittest.TestCase):
                 develop: images.scrapinghub.com/project/123
                 success: images.scrapinghub.com/project/456
         """)
-        with self.assertRaises(BadParameterException):
+        with self.assertRaises(BadConfigException):
             self.conf.get_image('prod')
-        with self.assertRaises(BadParameterException):
+        with self.assertRaises(BadConfigException):
             self.conf.get_image('develop')
         self.assertEqual(self.conf.get_image('success'),
                          SH_IMAGES_REPOSITORY.format(project=456))
 
     def test_get_image_ambigious(self):
-        with self.assertRaises(BadParameterException):
+        with self.assertRaises(BadConfigException):
             self.conf.load("""
                 projects:
                     default:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -534,7 +534,7 @@ class ShubConfigTest(unittest.TestCase):
         self.assertEqual(self.conf.get_image('success'),
                          SH_IMAGES_REPOSITORY.format(project=456))
 
-    def test_get_image_ambigious(self):
+    def test_get_image_ambigious_deprecated_images_section(self):
         with self.assertRaises(BadConfigException):
             self.conf.load("""
                 projects:
@@ -546,6 +546,53 @@ class ShubConfigTest(unittest.TestCase):
                 images:
                     default: custom/image
             """)
+        self.conf.load("""
+            projects:
+                default:
+                    id: 123
+                stacks:
+                    id: 322
+                    image: false
+                    stack: scrapy:1.2
+            image: custom/image
+        """)
+
+    def test_get_image_ambiguous_global_image_and_global_stack(self):
+        self.conf.load("""
+            project: 123
+            image: true
+            stack: scrapy:1.3
+        """)
+        with self.assertRaisesRegexp(BadConfigException, '(?i)ambiguous'):
+            self.conf.get_image('default')
+
+    def test_get_image_ambiguous_global_image_and_project_stack(self):
+        self.conf.load("""
+            projects:
+              bad:
+                id: 123
+                stack: scrapy:1.3
+              good:
+                id: 456
+                image: false
+                stack: scrapy:1.3
+            image: true
+            """)
+        with self.assertRaisesRegexp(BadConfigException, '(?i)ambiguous'):
+            self.conf.get_image('bad')
+        with self.assertRaisesRegexp(BadConfigException, '(?i)disabled'):
+            self.conf.get_image('good')
+
+    def test_get_image_ambiguous_project_image_and_project_stack(self):
+        self.conf.load("""
+            projects:
+              default:
+                id: 123
+                image: true
+                stack: scrapy:1.3
+            """)
+        with self.assertRaisesRegexp(BadConfigException, '(?i)ambiguous'):
+            self.conf.get_image('default')
 
     def test_get_target_conf(self):
         self.assertEqual(


### PR DESCRIPTION
Fail with an "ambiguous configuration" error message and a link for these three ambiguous configurations:

1. Both global non-false `image` and global `stack` configured
2. Global `image` configured and target project has `stack` option but not `image: false`
3. Target project has both `stack` option and non-false `image` option

Also replaces a couple of `BadParameterException`s that were raised on bad configurations with `BadConfigException`s (/cc @vshlapakov)