### PR TITLE
Make progress bar output tests independent of formatting details

### DIFF
--- a/tests/image/test_build.py
+++ b/tests/image/test_build.py
@@ -7,7 +7,7 @@ from click.testing import CliRunner
 
 from shub import exceptions as shub_exceptions
 from shub.image.build import cli
-from ..utils import format_expected_progress
+from ..utils import clean_progress_output, format_expected_progress
 
 
 @pytest.fixture
@@ -43,12 +43,12 @@ def test_cli_with_progress(docker_client_mock, project_dir, test_mock):
     result = runner.invoke(cli, ["dev"])
     assert result.exit_code == 0
     expected = format_expected_progress(
-        'Building registry/user/project:1.0.\n\r'
-        'Steps:   0%|          | 0/1\r'
-        'Steps: 100%|██████████| 3/3\n'
-        'The image registry/user/project:1.0 build is completed.\n'
+        'Building registry/user/project:1.0.'
+        'Steps:   0%|          | 0/1'
+        'Steps: 100%|██████████| 3/3'
+        'The image registry/user/project:1.0 build is completed.'
     )
-    assert expected in result.output
+    assert expected in clean_progress_output(result.output)
 
 
 def test_cli_custom_version(docker_client_mock, project_dir, test_mock):

--- a/tests/image/test_push.py
+++ b/tests/image/test_push.py
@@ -10,7 +10,7 @@ from shub import exceptions as shub_exceptions
 from shub.image.push import cli
 from shub.image.utils import ProgressBar
 
-from ..utils import format_expected_progress
+from ..utils import clean_progress_output, format_expected_progress
 
 
 @pytest.fixture
@@ -77,24 +77,24 @@ def test_cli_with_progress(docker_client_mock):
     result = runner.invoke(cli, ["dev", "--version", "test"])
     assert result.exit_code == 0
     expected = format_expected_progress(
-        'Login to registry succeeded.\n'
-        'Pushing registry/user/project:test to the registry.\n\r'
-        'Layers:   0%|          | 0/1\r          \r'
-        'Layers:   0%|          | 0/1\r          \r'
-        'Layers:   0%|          | 0/2\r          \r'
-        'Layers:   0%|          | 0/3\r          \r'
-        'Layers:   0%|          | 0/3\r          \r'
-        'Layers:   0%|          | 0/3\n\r'
-        'abc:   2%|▏         | 512/24.8K [1.00MB/s]\x1b[A\r          \r'
-        'Layers:   0%|          | 0/3\n\n\r'
-        'egh: 100%|██████████| 57.3K/57.3K [1.00MB/s]\x1b[A\x1b[A\r          \r'
-        'Layers:  33%|███▎      | 1/3\r          \r'
-        'Layers:  67%|██████▋   | 2/3\r'
-        'Layers: 100%|██████████| 3/3\n\r'
-        'abc: 100%|██████████| 24.8K/24.8K [1.00MB/s]\n\n'
-        'The image registry/user/project:test pushed successfully.\n'
+        'Login to registry succeeded.'
+        'Pushing registry/user/project:test to the registry.'
+        'Layers:   0%|          | 0/1          '
+        'Layers:   0%|          | 0/1          '
+        'Layers:   0%|          | 0/2          '
+        'Layers:   0%|          | 0/3          '
+        'Layers:   0%|          | 0/3          '
+        'Layers:   0%|          | 0/3'
+        'abc:   2%|▏         | 512/24.8K [1.00MB/s]          '
+        'Layers:   0%|          | 0/3'
+        'egh: 100%|██████████| 57.3K/57.3K [1.00MB/s]          '
+        'Layers:  33%|███▎      | 1/3          '
+        'Layers:  67%|██████▋   | 2/3'
+        'Layers: 100%|██████████| 3/3'
+        'abc: 100%|██████████| 24.8K/24.8K [1.00MB/s]'
+        'The image registry/user/project:test pushed successfully.'
     )
-    assert expected in result.output
+    assert expected in clean_progress_output(result.output)
 
 
 @pytest.mark.usefixtures('project_dir', 'test_mock')
@@ -123,25 +123,25 @@ def test_progress_no_total(docker_client_mock):
     result = runner.invoke(cli, ["dev", "--version", "test"])
     assert result.exit_code == 0
     expected = format_expected_progress(
-        'Layers:   0%|          | 0/1\r          \r'
-        'Layers:   0%|          | 0/1\r          \r'
-        'Layers:   0%|          | 0/2\r          \r'
-        'Layers:   0%|          | 0/3\r          \r'
-        'Layers:   0%|          | 0/4\r          \r'
-        'Layers:   0%|          | 0/4\r          \r'
-        'Layers:   0%|          | 0/4\r          \r'
-        'Layers:   0%|          | 0/4\n\r'
-        'abc: 100%|██████████| 512/512 [1.00MB/s]\x1b[A\r          \r'
-        'Layers:   0%|          | 0/4\n\n\r'
-        'egh: 100%|██████████| 57.3K/57.3K [1.00MB/s]\x1b[A\x1b[A\r          \r'
-        'Layers:  25%|██▌       | 1/4\r          \r'
-        'Layers:  50%|█████     | 2/4\r          \r'
-        'Layers:  75%|███████▌  | 3/4\r'
-        'Layers: 100%|██████████| 4/4\n\r'
-        'abc: 100%|██████████| 24.8K/24.8K [1.00MB/s]\n\n'
-        'The image registry/user/project:test pushed successfully.\n'
+        'Layers:   0%|          | 0/1          '
+        'Layers:   0%|          | 0/1          '
+        'Layers:   0%|          | 0/2          '
+        'Layers:   0%|          | 0/3          '
+        'Layers:   0%|          | 0/4          '
+        'Layers:   0%|          | 0/4          '
+        'Layers:   0%|          | 0/4          '
+        'Layers:   0%|          | 0/4'
+        'abc: 100%|██████████| 512/512 [1.00MB/s]          '
+        'Layers:   0%|          | 0/4'
+        'egh: 100%|██████████| 57.3K/57.3K [1.00MB/s]          '
+        'Layers:  25%|██▌       | 1/4          '
+        'Layers:  50%|█████     | 2/4          '
+        'Layers:  75%|███████▌  | 3/4'
+        'Layers: 100%|██████████| 4/4'
+        'abc: 100%|██████████| 24.8K/24.8K [1.00MB/s]'
+        'The image registry/user/project:test pushed successfully.'
     )
-    assert expected in result.output
+    assert expected in clean_progress_output(result.output)
 
 
 @pytest.mark.usefixtures('project_dir')

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 import sys
-import mock
+import re
 
+import mock
 from click.testing import CliRunner
 from tqdm._utils import _supports_unicode
 
@@ -69,3 +70,17 @@ def format_expected_progress(progress):
         for sym in to_replace:
             progress = progress.replace(sym, to_replace[sym])
     return progress
+
+
+def clean_progress_output(output):
+    """Return output cleaned from \\r, \\n, and ANSI escape sequences"""
+    return re.sub(
+        r"""(?x)      # Matches:
+        \n|\r|        # 1. newlines or carriage returns, or
+        (\x1b\[|\x9b) # 2. ANSI control sequence introducer ("ESC[" or single
+                      #    byte \x9b) +
+        [^@-_]*[@-_]| #    private mode characters + command character, or
+        \x1b[@-_]     # 3. ANSI control codes without sequence introducer
+                      #    ("ESC"  + single command character)
+        """,
+        '', output)


### PR DESCRIPTION
Our tests for the progress bar output during custom image building/pushing sometimes randomly fail. This is because the output of carriage returns, newlines, and ANSI escape sequences is dependent on the machine that runs the test.

For example, [this test](https://ci.appveyor.com/project/scrapinghub/shub/build/master-554/job/5e7mabanrd3cppe4#L138) failed because the actual output was `\x1b[A\\n\\x1b[AThe image registry/user/project:test pushed successfully.` while the expected output was `\\n\\nThe image registry/user/project:test pushed successfully.`

This PR should make the tests consistent by stripping these characters before checking the expected output.