### PR TITLE
Describe SHUB_JOB_DATA env variable

### DIFF
--- a/docs/custom-images-contract.rst
+++ b/docs/custom-images-contract.rst
@@ -126,7 +126,8 @@ If you specified some custom metadata with ``meta`` field when scheduling the jo
 
 .. warning::
 
-    There could be some other fields but it's for internal use only and not a part of the contract.
+    ``SHUB_JOB_DATA`` may contain other undocumented fields. They are for the platform's internal use
+     and are not part of the contract, i.e. they can appear or be removed anytime.
 
 
 SHUB_SETTINGS

--- a/docs/custom-images-contract.rst
+++ b/docs/custom-images-contract.rst
@@ -90,14 +90,44 @@ SHUB_JOB_DATA
 
 Job arguments, in JSON format.
 
+
 **Example**:
 
 .. code-block:: javascript
 
     {"key": "1111112/2/2", "project": 1111112, "version": "version1",
-    "spider": "spider-name", "spider_type": "auto", "tags": [],
-    "priority": 2, "scheduled_by": "user", "started_by": "admin",
+    "spider": "spider-name", "spider_type": "auto", "tags": ["tagA", "tagB"],
+    "priority": 2, "scheduled_by": "user", "started_by": "john",
     "pending_time": 1460374516193, "running_time": 1460374557448, ... }
+
+
+Some useful fields
+__________________
+
+============ ======================================================== =================================
+Field        Description                                              Example
+============ ======================================================== =================================
+key          Job key in format ``PROJECT_ID/SPIDER_ID/JOB_ID``        ``"1111112/2/2"``
+project      Integer project ID                                       ``1111112``
+spider       String spider name                                       ``"spider-name"``
+spider_args  Spider args dictionary                                   ``{"arg1":"val1"}``
+version      String project version used to run the job               ``"version1"``
+units        Amount of units used by the job                          ``1``
+priority     Job priority value                                       ``2``
+tags         List of string tags for the job                          ``["tagA", "tagB"]``
+state        Job current state name                                   ``"running"``
+pending_time UNIX timestamp when the job was added, in milliseconds   ``1460374516193``
+running_time UNIX timestamp when the job was started, in milliseconds ``1460374557448``
+auth         Job authentication string to access job data             ``""eyJ0e***.eyJhd***.9H5Oq***"``
+scheduled_by Username who scheduled the job                           ``"john"``
+============ ======================================================== =================================
+
+If you specified some custom metadata with ``meta`` field when scheduling the job, the data will also be in the dictionary.
+
+.. warning::
+
+    There could be some other fields but it's for internal use only and not a part of the contract.
+
 
 SHUB_SETTINGS
 ^^^^^^^^^^^^^

--- a/docs/custom-images-contract.rst
+++ b/docs/custom-images-contract.rst
@@ -109,13 +109,13 @@ Field        Description                                              Example
 key          Job key in format ``PROJECT_ID/SPIDER_ID/JOB_ID``        ``"1111112/2/2"``
 project      Integer project ID                                       ``1111112``
 spider       String spider name                                       ``"spider-name"``
-job_cmd      JSON list of string arguments for the job                ``["--flagA", "--key1=value1"]``
-spider_args  Spider args dictionary                                   ``{"arg1": "val1"}``
+job_cmd      List of string arguments for the job                     ``["--flagA", "--key1=value1"]``
+spider_args  Dictionary with spider arguments                         ``{"arg1": "val1"}``
 version      String project version used to run the job               ``"version1"``
 deploy_id    Integer project deploy ID used to run the job            ``253``
 units        Amount of units used by the job                          ``1``
 priority     Job priority value                                       ``2``
-tags         JSON list of string tags for the job                     ``["tagA", "tagB"]``
+tags         List of string tags for the job                          ``["tagA", "tagB"]``
 state        Job current state name                                   ``"running"``
 pending_time UNIX timestamp when the job was added, in milliseconds   ``1460374516193``
 running_time UNIX timestamp when the job was started, in milliseconds ``1460374557448``

--- a/docs/custom-images-contract.rst
+++ b/docs/custom-images-contract.rst
@@ -109,15 +109,16 @@ Field        Description                                              Example
 key          Job key in format ``PROJECT_ID/SPIDER_ID/JOB_ID``        ``"1111112/2/2"``
 project      Integer project ID                                       ``1111112``
 spider       String spider name                                       ``"spider-name"``
-spider_args  Spider args dictionary                                   ``{"arg1":"val1"}``
+job_cmd      JSON list of string arguments for the job                ``["--flagA", "--key1=value1"]``
+spider_args  Spider args dictionary                                   ``{"arg1": "val1"}``
 version      String project version used to run the job               ``"version1"``
+deploy_id    Integer project deploy ID used to run the job            ``253``
 units        Amount of units used by the job                          ``1``
 priority     Job priority value                                       ``2``
-tags         List of string tags for the job                          ``["tagA", "tagB"]``
+tags         JSON list of string tags for the job                     ``["tagA", "tagB"]``
 state        Job current state name                                   ``"running"``
 pending_time UNIX timestamp when the job was added, in milliseconds   ``1460374516193``
 running_time UNIX timestamp when the job was started, in milliseconds ``1460374557448``
-auth         Job authentication string to access job data             ``""eyJ0e***.eyJhd***.9H5Oq***"``
 scheduled_by Username who scheduled the job                           ``"john"``
 ============ ======================================================== =================================
 

--- a/docs/custom-images-contract.rst
+++ b/docs/custom-images-contract.rst
@@ -90,7 +90,6 @@ SHUB_JOB_DATA
 
 Job arguments, in JSON format.
 
-
 **Example**:
 
 .. code-block:: javascript


### PR DESCRIPTION
Please review and let me know if it can be improve in some way. There're some fields I haven't include in the list because think they are internal, also probably we should provide more real-life examples (at least for custom ``meta`` items if we're going to support it in the future).