### PR TITLE
Replace list-spiders with shub-image-info

### DIFF
--- a/shub/image/list.py
+++ b/shub/image/list.py
@@ -74,14 +74,14 @@ def list_cmd(image_name, project, endpoint, apikey):
     elif exit_code == 127:
         # FIXME we should pass some value for SCRAPY_PROJECT_ID anyway
         # to handle `scrapy list` cmd properly via sh_scrapy entrypoint
-        environment['SCRAPY_PROJECT_ID'] = str(project) if project else ''
+        # environment['SCRAPY_PROJECT_ID'] = str(project) if project else ''
         exit_code, logs = _run_cmd_in_docker_container(
             image_name, 'list-spiders', environment)
         if exit_code != 0:
             click.echo(logs)
             raise ShubException('Container with list cmd exited with code %s' % exit_code)
         logs = logs.decode('utf-8') if isinstance(logs, binary_type) else logs
-        return {'spiders': utils.valid_spiders(logs)}
+        return {'spiders': utils.valid_spiders(logs.splitlines())}
     else:
         click.echo(logs)
         raise ShubException(
@@ -145,4 +145,7 @@ def _extract_metadata_from_image_info_output(output):
         if not (name and isinstance(name, string_types)):
             raise_shub_image_info_error("spider name can't be empty or non-string")
         scripts.append(name[3:]) if name.startswith('py:') else spiders.append(name)
-    return {'spiders': spiders, 'scripts': scripts}
+    return {
+        'spiders': utils.valid_spiders(spiders),
+        'scripts': utils.valid_spiders(scripts),
+    }

--- a/shub/image/list.py
+++ b/shub/image/list.py
@@ -1,11 +1,13 @@
 import json
 
 import click
+import docker
 import requests
 from six import binary_type
+from six import string_types
 from six.moves.urllib.parse import urljoin
 
-from shub import exceptions as shub_exceptions
+from shub.exceptions import ShubException
 from shub.config import load_shub_config, list_targets_callback
 from shub.image import utils
 
@@ -52,27 +54,38 @@ def list_cmd_full(target, silent, version):
     version = version or config.get_version()
     image_name = utils.format_image_name(image, version)
     target_conf = config.get_target_conf(target)
-    for spider in list_cmd(image_name,
-                           target_conf.project_id,
-                           target_conf.endpoint,
-                           target_conf.apikey):
+    metadata = list_cmd(image_name,
+                        target_conf.project_id,
+                        target_conf.endpoint,
+                        target_conf.apikey)
+    for spider in metadata.get('spiders', []):
         click.echo(spider)
 
 
 def list_cmd(image_name, project, endpoint, apikey):
     """Short version of list cmd to use with deploy cmd."""
     settings = _get_project_settings(project, endpoint, apikey)
-
-    # Run a local docker container to run list-spiders cmd
-    status_code, logs = _run_list_cmd(project, image_name, settings)
-    if status_code != 0:
+    environment = {'JOB_SETTINGS': json.dumps(settings)}
+    exit_code, logs = _run_cmd_in_docker_container(
+            image_name, 'shub-image-info', environment)
+    if exit_code == 0:
+        return _extract_metadata_from_image_info_output(logs)
+    # shub-image-info command not found, fallback to list-spiders
+    elif exit_code == 127:
+        # FIXME we should pass some value for SCRAPY_PROJECT_ID anyway
+        # to handle `scrapy list` cmd properly via sh_scrapy entrypoint
+        environment['SCRAPY_PROJECT_ID'] = str(project) if project else ''
+        exit_code, logs = _run_cmd_in_docker_container(
+            image_name, 'list-spiders', environment)
+        if exit_code != 0:
+            click.echo(logs)
+            raise ShubException('Container with list cmd exited with code %s' % exit_code)
+        logs = logs.decode('utf-8') if isinstance(logs, binary_type) else logs
+        return {'spiders': utils.valid_spiders(logs)}
+    else:
         click.echo(logs)
-        raise shub_exceptions.ShubException(
-            'Container with list cmd exited with code %s' % status_code)
-
-    spiders = utils.valid_spiders(
-        logs.decode('utf-8') if isinstance(logs, binary_type) else logs)
-    return spiders
+        raise ShubException(
+            'Container with shub-image-info cmd exited with code %s' % exit_code)
 
 
 def _get_project_settings(project, endpoint, apikey):
@@ -89,27 +102,47 @@ def _get_project_settings(project, endpoint, apikey):
     return {k: v for k, v in req.json().items() if k in SETTING_TYPES}
 
 
-def _run_list_cmd(project, image_name, project_settings):
-    """Run `scrapy list` command inside the image container."""
-
+def _run_cmd_in_docker_container(image_name, command, environment):
+    """Run a command inside the image container."""
     client = utils.get_docker_client()
-    # FIXME we should pass some value for SCRAPY_PROJECT_ID anyway
-    # to handle `scrapy list` cmd properly via sh_scrapy entrypoint
-    project = str(project) if project else ''
-    job_settings = json.dumps(project_settings)
     container = client.create_container(
         image=image_name,
-        command=['list-spiders'],
-        environment={'SCRAPY_PROJECT_ID': project,
-                     'JOB_SETTINGS': job_settings})
+        command=[command],
+        environment=environment,
+    )
     if 'Id' not in container:
-        raise shub_exceptions.ShubException(
-            "Create container error:\n %s" % container)
-
-    client.start(container)
+        raise ShubException("Create container error:\n %s" % container)
+    try:
+        client.start(container)
+    except docker.errors.NotFound:
+        # return a proper exit code if executable is not found
+        return 127, None
     statuscode = client.wait(container=container['Id'])
-
     return statuscode, client.logs(
             container=container['Id'],
             stdout=True, stderr=True if statuscode else False,
             stream=False, timestamps=False)
+
+
+def _extract_metadata_from_image_info_output(output):
+    """Extract and validate spiders list from `shub-image-info` output."""
+
+    def raise_shub_image_info_error(error):
+        """Helper to raise ShubException with prefix and output"""
+        msg = "shub-image-info: {} \n[output '{}']".format(error, output)
+        raise ShubException(msg)
+
+    try:
+        metadata = json.loads(output)
+        spiders_list = metadata.get('spiders', [])
+    except (ValueError, AttributeError):
+        raise_shub_image_info_error('output is not a valid JSON dict')
+    if not isinstance(spiders_list, list):
+        raise_shub_image_info_error('spiders section must be a list')
+
+    spiders, scripts = [], []
+    for name in spiders_list:
+        if not (name and isinstance(name, string_types)):
+            raise_shub_image_info_error("spider name can't be empty or non-string")
+        scripts.append(name[3:]) if name.startswith('py:') else spiders.append(name)
+    return {'spiders': spiders, 'scripts': scripts}

--- a/shub/image/utils.py
+++ b/shub/image/utils.py
@@ -203,14 +203,14 @@ def _update_status_file(data, path):
         yaml.dump(data, status_file, default_flow_style=False)
 
 
-def valid_spiders(buf):
+def valid_spiders(entries):
     """Filter out garbage and only let valid spider names in
-    >>> _valid_spiders('Update rootfs\\nsony.com\\n\\nsoa-uk\\n182-blink.com')
+    >>> _valid_spiders(['Update rootfs','sony.com', '', 'soa-uk', '182-blink.com'])
     ['182-blink.com', 'soa-uk', 'sony.com']
-    >>> _valid_spiders('-spiders\\nA77aque')
+    >>> _valid_spiders(['-spiders', 'A77aque'])
     ['A77aque']
     """
-    return sorted(filter(_VALIDSPIDERNAME.match, buf.splitlines()))
+    return sorted(filter(_VALIDSPIDERNAME.match, entries))
 
 
 class BaseProgress(object):

--- a/tests/image/test_deploy.py
+++ b/tests/image/test_deploy.py
@@ -31,7 +31,7 @@ def mocked_post(monkeypatch):
 @mock.patch('requests.post')
 @mock.patch('shub.image.list.list_cmd')
 def test_cli(list_mocked, post_mocked, get_mocked):
-    list_mocked.return_value = ['a1f', 'abc', 'spi-der']
+    list_mocked.return_value = {'spiders': ['a1f', 'abc', 'spi-der']}
     post_req = mock.Mock()
     post_req.headers = {'location': 'https://status-url'}
     post_mocked.return_value = post_req
@@ -59,7 +59,7 @@ def test_cli(list_mocked, post_mocked, get_mocked):
 @mock.patch('requests.post')
 @mock.patch('shub.image.list.list_cmd')
 def test_cli_insecure_registry(list_mocked, post_mocked, get_mocked):
-    list_mocked.return_value = ['a1f', 'abc', 'spi-der']
+    list_mocked.return_value = {'spiders': ['a1f', 'abc', 'spi-der']}
     post_req = mock.Mock()
     post_req.headers = {'location': 'https://status-url'}
     post_mocked.return_value = post_req
@@ -197,18 +197,18 @@ def test_progress_bar_logic_incomplete():
 # Tests for auxiliary functions
 
 def test_extract_scripts_from_project_empty():
-    assert _extract_scripts_from_project() == ''
+    assert _extract_scripts_from_project() == []
 
 
 @pytest.mark.usefixtures('project_dir')
 def test_extract_scripts_from_project_fake():
-    assert _extract_scripts_from_project() == 'scriptA.py,scriptB.py'
+    assert _extract_scripts_from_project() == ['scriptA.py', 'scriptB.py']
 
 
 @pytest.mark.usefixtures('project_dir')
 @mock.patch('shub.image.list.list_cmd')
 def test_prepare_deploy_params(mocked):
-    mocked.return_value = ['a1f', 'abc', 'spi-der']
+    mocked.return_value = {'spiders': ['a1f', 'abc', 'spi-der']}
     expected = {
         'image_url': 'registry/user/project',
         'project': 123,
@@ -225,7 +225,7 @@ def test_prepare_deploy_params(mocked):
 @pytest.mark.usefixtures('project_dir')
 @mock.patch('shub.image.list.list_cmd')
 def test_prepare_deploy_params_more_params(mocked):
-    mocked.return_value = ['a1f', 'abc', 'spi-der']
+    mocked.return_value = {'spiders': ['a1f', 'abc', 'spi-der']}
     expected = {
         'image_url': 'registry/user/project',
         'project': 123,

--- a/tests/image/test_list.py
+++ b/tests/image/test_list.py
@@ -1,83 +1,119 @@
+import json
+
 import mock
+import pytest
 from click.testing import CliRunner
-from unittest import TestCase
 
+from shub.exceptions import  BadParameterException, ShubException
 from shub.image.list import cli
-from shub.image.list import _run_list_cmd
-
-from .utils import FakeProjectDirectory
-from .utils import add_sh_fake_config
+from shub.image.list import _run_cmd_in_docker_container
+from shub.image.list import _extract_metadata_from_image_info_output
 
 
-class TestListCli(TestCase):
-
-    def test_cli_no_sh_config(self):
-        runner = CliRunner()
-        result = runner.invoke(cli, ["dev", "-v", "--version", "test"])
-        assert result.exit_code == 64
-        assert 'Could not find target "dev"' in result.output
-
-    @mock.patch('shub.image.utils.get_docker_client')
-    @mock.patch('requests.get')
-    def test_cli_container_error(self, get_mocked, get_client_mock):
-        client_mock = mock.Mock()
-        client_mock.create_container.return_value = {'Id': '1234'}
-        client_mock.wait.return_value = 66
-        get_client_mock.return_value = client_mock
-
-        get_settings_mock = mock.Mock()
-        get_settings_mock.json.return_value = {}
-        get_mocked.return_value = get_settings_mock
-
-        with FakeProjectDirectory() as tmpdir:
-            add_sh_fake_config(tmpdir)
-            runner = CliRunner()
-            result = runner.invoke(cli, ["dev", "-v", "--version", "test"])
-            assert result.exit_code == 1
-            assert 'list cmd exited with code 66' in result.output
-
-    @mock.patch('shub.image.utils.get_docker_client')
-    @mock.patch('requests.get')
-    def test_cli(self, get_mocked, get_client_mock):
-        client_mock = mock.Mock()
-        client_mock.create_container.return_value = {'Id': '1234'}
-        client_mock.wait.return_value = 0
-        client_mock.logs.return_value = b'abc\ndef\ndsd'
-        get_client_mock.return_value = client_mock
-
-        get_settings_mock = mock.Mock()
-        get_settings_mock.json.return_value = {}
-        get_mocked.return_value = get_settings_mock
-
-        with FakeProjectDirectory() as tmpdir:
-            add_sh_fake_config(tmpdir)
-            runner = CliRunner()
-            result = runner.invoke(cli, [
-                "dev", "-v", "-s", "--version", "test"])
-            assert result.exit_code == 0
-            assert result.output.endswith('abc\ndef\ndsd\n')
-        get_mocked.assert_called_with(
-            'https://app.scrapinghub.com/api/settings/get.json',
-            allow_redirects=False, auth=('abcdef', ''),
-            params={'project': 12345}, timeout=300)
+def _mock_docker_client(wait_code=0, logs=None):
+    client_mock = mock.Mock()
+    client_mock.create_container.return_value = {'Id': '1234'}
+    client_mock.wait.return_value = wait_code
+    client_mock.logs.return_value = logs or ''
+    return client_mock
 
 
-class TestListCmd(TestCase):
+def _get_settings_mock(settings=None):
+    settings_mock = mock.Mock()
+    settings_mock.json.return_value = settings or {}
+    return settings_mock
 
-    @mock.patch('shub.image.utils.get_docker_client')
-    def test_run_list_cmd(self, get_client_mock):
-        client_mock = mock.Mock()
-        client_mock.create_container.return_value = {'Id': '1234'}
-        client_mock.wait.return_value = 0
-        client_mock.logs.return_value = 'abc\ndef\ndsd'
-        get_client_mock.return_value = client_mock
-        assert _run_list_cmd(1234, 'image', {})[0] == 0
-        client_mock.create_container.assert_called_with(
-            command=['list-spiders'], environment={
-                'JOB_SETTINGS': '{}',
-                'SCRAPY_PROJECT_ID': '1234'}, image='image')
-        client_mock.start.assert_called_with({'Id': '1234'})
-        client_mock.wait.assert_called_with(container="1234")
-        client_mock.logs.assert_called_with(
-            container='1234', stderr=False, stdout=True,
-            stream=False, timestamps=False)
+
+def test_cli_no_scrapinghub_config():
+    result = CliRunner().invoke(cli, ["dev", "-v", "--version", "test"])
+    assert result.exit_code == BadParameterException.exit_code
+    assert 'Could not find target "dev"' in result.output
+
+
+@pytest.mark.usefixtures('project_dir')
+@mock.patch('shub.image.utils.get_docker_client')
+@mock.patch('requests.get')
+def test_cli(requests_get_mock, get_docker_client_mock):
+    """Case when shub-image-info succeeded."""
+    requests_get_mock.return_value = _get_settings_mock()
+    mocked_logs = json.dumps({'spiders': ['abc', 'def']})
+    docker_client = _mock_docker_client(logs=mocked_logs)
+    get_docker_client_mock.return_value = docker_client
+    result = CliRunner().invoke(cli, ["dev", "-v", "-s", "--version", "test"])
+    assert result.exit_code == 0
+    assert result.output.endswith('abc\ndef\n')
+    requests_get_mock.assert_called_with(
+        'https://app.scrapinghub.com/api/settings/get.json',
+        allow_redirects=False, auth=('abcdef', ''),
+        params={'project': 12345}, timeout=300)
+
+
+@pytest.mark.usefixtures('project_dir')
+@mock.patch('shub.image.utils.get_docker_client')
+@mock.patch('requests.get')
+def test_cli_image_info_error(requests_get_mock, get_docker_client_mock):
+    """Case when shub-image-info command failed with unknown exit code."""
+    requests_get_mock.return_value = _get_settings_mock()
+    docker_client = _mock_docker_client(wait_code=1, logs='some-error')
+    get_docker_client_mock.return_value = docker_client
+    result = CliRunner().invoke(cli, ["dev", "-v", "--version", "test"])
+    assert result.exit_code == 1
+    assert 'Container with shub-image-info cmd exited with code 1' in result.output
+
+
+@pytest.mark.usefixtures('project_dir')
+@mock.patch('shub.image.utils.get_docker_client')
+@mock.patch('requests.get')
+def test_cli_image_info_not_found(requests_get_mock, get_docker_client_mock):
+    """Case when shub-image-info cmd not found with fallback to list-spiders."""
+    requests_get_mock.return_value = _get_settings_mock({'SETTING': 'VALUE'})
+    docker_client = _mock_docker_client()
+    docker_client.wait.side_effect = [127, 0]
+    docker_client.logs.side_effect = ["not-found", "spider1\nspider2\n"]
+    get_docker_client_mock.return_value = docker_client
+    result = CliRunner().invoke(cli, ["dev", "-v", "--version", "test"])
+    assert result.exit_code == 0
+    assert 'spider1\nspider2' in result.output
+
+
+@pytest.mark.usefixtures('project_dir')
+@mock.patch('shub.image.utils.get_docker_client')
+@mock.patch('requests.get')
+def test_cli_both_commands_failed(requests_get_mock, get_docker_client_mock):
+    """Case when shub-image-info cmd not found with fallback to list-spiders."""
+    requests_get_mock.return_value = _get_settings_mock({'SETTING': 'VALUE'})
+    docker_client = _mock_docker_client(wait_code=127, logs='not-found')
+    get_docker_client_mock.return_value = docker_client
+    result = CliRunner().invoke(cli, ["dev", "-v", "--version", "test"])
+    assert result.exit_code == 1
+    assert 'Container with list cmd exited with code 127' in result.output
+
+
+@mock.patch('shub.image.utils.get_docker_client')
+def test_run_cmd_in_docker_container(get_docker_client_mock):
+    docker_client = _mock_docker_client(logs='abc\ndef\ndsd')
+    get_docker_client_mock.return_value = docker_client
+    test_env = {'TEST_ENV1': 'VAL1', 'TEST_ENV2': 'VAL2'}
+    result = _run_cmd_in_docker_container('image', 'test-cmd', test_env)
+    assert result[0] == 0
+    assert result[1] == 'abc\ndef\ndsd'
+    docker_client.create_container.assert_called_with(
+        command=['test-cmd'], environment=test_env, image='image')
+    docker_client.start.assert_called_with({'Id': '1234'})
+    docker_client.wait.assert_called_with(container="1234")
+    docker_client.logs.assert_called_with(
+        container='1234', stderr=False, stdout=True,
+        stream=False, timestamps=False)
+
+
+@pytest.mark.parametrize('output,error_msg',[
+    ('bad-json', 'output is not a valid JSON'),
+    (json.dumps([]), 'output is not a valid JSON dict'),
+    (json.dumps({'spiders': 'spider'}), 'spiders section must be a list'),
+    (json.dumps({'spiders': ['']}), "spider name can't be empty or non-string"),
+    (json.dumps({'spiders': [123]}), "spider name can't be empty or non-string"),
+])
+def test_extract_metadata_from_image_info_output_failures(output, error_msg):
+    with pytest.raises(ShubException) as exc:
+        _extract_metadata_from_image_info_output(output)
+    assert error_msg in exc.value.message


### PR DESCRIPTION
We're introducing a new command to Kumo contract: it's called `shub-image-info` and will deprecate current `list-spiders`. Comparing with `list-spiders` command - the new command should return JSON encoded metadata for a given image, incl. a project type, spiders metadata and probably some other fields in the future. As now we're changing the way how arguments and settings are being passed to a spider/script, scripts become a Scrapy-specific feature, and should be included into the same spiders list with `py:` prefix.

Important note, that we must provide backward compatibility, so if `shub-image-info` is not found, there's fall back to `list-spiders` with a deprecation warning.

Please, review.