### PR TITLE
Extract and pass project_type on deploy

### DIFF
--- a/shub/image/deploy.py
+++ b/shub/image/deploy.py
@@ -198,9 +198,12 @@ def _prepare_deploy_params(project, version, image_name, endpoint, apikey,
     metadata = list_mod.list_cmd(image_name, project, endpoint, apikey)
     if 'scripts' not in metadata:
         metadata['scripts'] = _extract_scripts_from_project()
-    params = {'project': project,
-              'version': version,
-              'image_url': image_name}
+    params = {
+        'project': project,
+        'version': version,
+        'image_url': image_name,
+        'project_type': metadata['project_type'],
+    }
     if metadata.get('spiders'):
         params['spiders'] = ','.join(metadata['spiders'])
     if metadata.get('scripts'):

--- a/shub/image/list.py
+++ b/shub/image/list.py
@@ -137,13 +137,15 @@ def _extract_metadata_from_image_info_output(output):
 
     try:
         metadata = json.loads(output)
-        spiders_list = metadata.get('spiders', [])
-    except (ValueError, AttributeError):
+        project_type = metadata.get('project_type')
+    except (AttributeError, ValueError):
         raise_shub_image_info_error('output is not a valid JSON dict')
-    if not isinstance(spiders_list, list):
-        raise_shub_image_info_error('spiders section must be a list')
+    if not isinstance(project_type, string_types):
+        raise_shub_image_info_error('"project_type" key is required and must be a string')
 
-    project_type = metadata.get('project_type')
+    spiders_list = metadata.get('spiders')
+    if not isinstance(spiders_list, list):
+        raise_shub_image_info_error('"spiders" key is required and must be a list')
     spiders, scripts = [], []
     for name in spiders_list:
         if not (name and isinstance(name, string_types)):

--- a/tests/image/test_deploy.py
+++ b/tests/image/test_deploy.py
@@ -31,7 +31,10 @@ def mocked_post(monkeypatch):
 @mock.patch('requests.post')
 @mock.patch('shub.image.list.list_cmd')
 def test_cli(list_mocked, post_mocked, get_mocked):
-    list_mocked.return_value = {'spiders': ['a1f', 'abc', 'spi-der']}
+    list_mocked.return_value = {
+        'project_type': 'scrapy',
+        'spiders': ['a1f', 'abc', 'spi-der'],
+    }
     post_req = mock.Mock()
     post_req.headers = {'location': 'https://status-url'}
     post_mocked.return_value = post_req
@@ -44,12 +47,15 @@ def test_cli(list_mocked, post_mocked, get_mocked):
         'https://app.scrapinghub.com/api/releases/deploy.json',
         allow_redirects=False,
         auth=('abcdef', ''),
-        data={'project': 12345,
-              'version': u'test',
-              'pull_auth_config': auth_cfg,
-              'image_url': 'registry/user/project:test',
-              'spiders': 'a1f,abc,spi-der',
-              'scripts': 'scriptA.py,scriptB.py'},
+        data={
+            'project_type': 'scrapy',
+            'project': 12345,
+            'version': u'test',
+            'pull_auth_config': auth_cfg,
+            'image_url': 'registry/user/project:test',
+            'spiders': 'a1f,abc,spi-der',
+            'scripts': 'scriptA.py,scriptB.py',
+        },
         timeout=300)
     get_mocked.assert_called_with('https://status-url', timeout=300)
 
@@ -59,7 +65,10 @@ def test_cli(list_mocked, post_mocked, get_mocked):
 @mock.patch('requests.post')
 @mock.patch('shub.image.list.list_cmd')
 def test_cli_insecure_registry(list_mocked, post_mocked, get_mocked):
-    list_mocked.return_value = {'spiders': ['a1f', 'abc', 'spi-der']}
+    list_mocked.return_value = {
+        'project_type': 'scrapy',
+        'spiders': ['a1f', 'abc', 'spi-der'],
+    }
     post_req = mock.Mock()
     post_req.headers = {'location': 'https://status-url'}
     post_mocked.return_value = post_req
@@ -71,12 +80,15 @@ def test_cli_insecure_registry(list_mocked, post_mocked, get_mocked):
         'https://app.scrapinghub.com/api/releases/deploy.json',
         allow_redirects=False,
         auth=('abcdef', ''),
-        data={'project': 12345,
-              'version': u'test',
-              'pull_insecure_registry': True,
-              'image_url': 'registry/user/project:test',
-              'spiders': 'a1f,abc,spi-der',
-              'scripts': 'scriptA.py,scriptB.py'},
+        data={
+            'project_type': 'scrapy',
+            'project': 12345,
+            'version': u'test',
+            'pull_insecure_registry': True,
+            'image_url': 'registry/user/project:test',
+            'spiders': 'a1f,abc,spi-der',
+            'scripts': 'scriptA.py,scriptB.py',
+        },
         timeout=300)
     get_mocked.assert_called_with('https://status-url', timeout=300)
 
@@ -208,8 +220,11 @@ def test_extract_scripts_from_project_fake():
 @pytest.mark.usefixtures('project_dir')
 @mock.patch('shub.image.list.list_cmd')
 def test_prepare_deploy_params(mocked):
-    mocked.return_value = {'spiders': ['a1f', 'abc', 'spi-der']}
+    mocked.return_value = {
+        'project_type': 'scrapy',
+        'spiders': ['a1f', 'abc', 'spi-der']}
     expected = {
+        'project_type': 'scrapy',
         'image_url': 'registry/user/project',
         'project': 123,
         'pull_insecure_registry': True,
@@ -225,8 +240,12 @@ def test_prepare_deploy_params(mocked):
 @pytest.mark.usefixtures('project_dir')
 @mock.patch('shub.image.list.list_cmd')
 def test_prepare_deploy_params_more_params(mocked):
-    mocked.return_value = {'spiders': ['a1f', 'abc', 'spi-der']}
+    mocked.return_value = {
+        'project_type': 'scrapy',
+        'spiders': ['a1f', 'abc', 'spi-der'],
+    }
     expected = {
+        'project_type': 'scrapy',
         'image_url': 'registry/user/project',
         'project': 123,
         'scripts': 'scriptA.py,scriptB.py',


### PR DESCRIPTION
shub tool should extract `project_type` info from `shub-image-info` and pass it on deploy.

Review, please.