### PR TITLE
shub-image-info output should be a single line

### DIFF
--- a/docs/custom-images-contract.rst
+++ b/docs/custom-images-contract.rst
@@ -37,12 +37,8 @@ Contract statements
 
 .. code-block:: bash
 
-   docker run myscrapyimage shub-image-info
-
-    {
-        "project_type": "casperjs",
-        "spiders": ["spiderA", "spiderB"]
-    }
+    docker run myscrapyimage shub-image-info
+    {"project_type": "casperjs", "spiders": ["spiderA", "spiderB"]}
 
 .. note::
 


### PR DESCRIPTION
We assume that when parse command output but docs suggest multiline output