### PR TITLE
Handle Bytes input to JSON in Python 3

### DIFF
--- a/shub/image/list.py
+++ b/shub/image/list.py
@@ -3,6 +3,7 @@ import json
 import click
 import docker
 import requests
+import six
 from six import binary_type
 from six import string_types
 from six.moves.urllib.parse import urljoin
@@ -142,7 +143,10 @@ def _extract_metadata_from_image_info_output(output):
         raise ShubException(msg)
 
     try:
-        metadata = json.loads(output)
+        if six.PY2:
+            metadata = json.loads(output)
+        else:
+            metadata = json.loads(output.decode('utf-8'))
         project_type = metadata.get('project_type')
     except (AttributeError, ValueError):
         raise_shub_image_info_error('output is not a valid JSON dict')

--- a/shub/image/list.py
+++ b/shub/image/list.py
@@ -146,7 +146,10 @@ def _extract_metadata_from_image_info_output(output):
         if six.PY2:
             metadata = json.loads(output)
         else:
-            metadata = json.loads(output.decode('utf-8'))
+            if isinstance(output, str):
+                metadata = json.loads(output)
+            else:
+                metadata = json.loads(output.decode('utf-8'))
         project_type = metadata.get('project_type')
     except (AttributeError, ValueError):
         raise_shub_image_info_error('output is not a valid JSON dict')


### PR DESCRIPTION
I encountered a bug in Python 3.5.2 where some inputs to `json.loads` within `shub/image/list.py` were being passed as `bytes`, which lead to crashing. The fix is inelegant, but it passes tests on 2.7 and 3.5.