### PR TITLE
Extract scripts if not found in shub-image-info

### DIFF
--- a/shub/image/deploy.py
+++ b/shub/image/deploy.py
@@ -196,7 +196,7 @@ def _prepare_deploy_params(project, version, image_name, endpoint, apikey,
                            username, password, email):
     # Reusing shub.image.list logic to get spiders list
     metadata = list_mod.list_cmd(image_name, project, endpoint, apikey)
-    if 'scripts' not in metadata:
+    if not metadata.get('scripts'):
         metadata['scripts'] = _extract_scripts_from_project()
     params = {
         'project': project,


### PR DESCRIPTION
According to the last changes in [SH contract](https://shub.readthedocs.io/en/stable/custom-images-contract.html), there's `shub-image-info` command responsible for getting metadata and spiders list from a custom image. And we still support scripts in SH, so there's a need to get it in a similar way. However we can't implement getting scripts in default `shub-image-info` implementation in `scrapinghub-entrypoint-scrapy` (because it knows nothing about main project python egg and its internals), but we still should provide some workaround to make it work with custom images.

My proposal here is to always try to extract scripts if they're not found in `shub-image-info` output. Additional time is small, but this trick will help to solve the problem and bring scripts to custom images with `shub-image-info`.

Please, review.