### PR TITLE
Allow custom Dockerfile names

### DIFF
--- a/docs/deploy-custom-image.rst
+++ b/docs/deploy-custom-image.rst
@@ -204,6 +204,12 @@ Option to skip testing image with ``shub image test`` after build.
 
 Increase the tool's verbosity.
 
+.. function:: -f/--file
+
+Use this option to pass a custom Dockerfile name (default is 'PATH/Dockerfile').
+
+**Default value**: ``Dockerfile``
+
 **Example:**
 
 ::

--- a/shub/image/upload.py
+++ b/shub/image/upload.py
@@ -34,15 +34,18 @@ Obviously it accepts all the options for the commands above.
 @click.option("--async", is_flag=True, help="[DEPRECATED] enable asynchronous mode",
               callback=utils.deprecate_async_parameter)
 @click.option("-S", "--skip-tests", help="skip testing image", is_flag=True)
+@click.option("-f", "--file", "filename", default='Dockerfile',
+              help="Name of the Dockerfile (Default is 'PATH/Dockerfile')")
 def cli(target, debug, verbose, version, username, password, email,
-        apikey, insecure, async, skip_tests):
+        apikey, insecure, async, skip_tests, filename):
     upload_cmd(target, version, username, password, email, apikey, insecure,
-               async, skip_tests)
+               async, skip_tests, filename)
 
 
 def upload_cmd(target, version, username=None, password=None, email=None,
-               apikey=None, insecure=False, async=False, skip_tests=False):
-    build.build_cmd(target, version, skip_tests)
+               apikey=None, insecure=False, async=False, skip_tests=False,
+               filename='Dockerfile'):
+    build.build_cmd(target, version, skip_tests, filename=filename)
     # skip tests for push command anyway because they run in build command if not skipped
     push.push_cmd(target, version, username, password, email, apikey,
                   insecure, skip_tests=True)

--- a/tests/image/test_upload.py
+++ b/tests/image/test_upload.py
@@ -15,9 +15,9 @@ class TestUploadCli(TestCase):
             cli, ["dev", "-v", "--version", "test",
                   "--username", "user", "--password", "pass",
                   "--email", "mail", "--async", "--apikey", "apikey",
-                  "--skip-tests"])
+                  "--skip-tests", "-f", "Dockerfile"])
         assert result.exit_code == 0
-        build.assert_called_with('dev', 'test', True)
+        build.assert_called_with('dev', 'test', True, filename='Dockerfile')
         push.assert_called_with(
             'dev', 'test', 'user', 'pass', 'mail', "apikey", False, skip_tests=True)
         deploy.assert_called_with(


### PR DESCRIPTION
This modification allows to pass a custom Dockerfile name instead of assuming the default value ('Dockerfile') when building images. This is useful when you want to manage different Dockerfiles in the same repo.