### PR TITLE
Replace doc.sh.com links with actual ones

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,21 @@
 from __future__ import absolute_import
+import io
+import os
 from setuptools import setup, find_packages
+
+
+about = {}
+here = os.path.abspath(os.path.dirname(__file__))
+with io.open(os.path.join(here, 'shub', '__init__.py'),
+             mode='r', encoding='utf-8') as f:
+    exec(f.read(), about)
 
 
 setup(
     name='shub',
     version='2.7.0',
     packages=find_packages(exclude=('tests', 'tests.*')),
-    url='http://doc.scrapinghub.com/shub.html',
+    url=about['DOCS_LINK'],
     description='Scrapinghub Command Line Client',
     long_description=open('README.rst').read(),
     author='Scrapinghub',

--- a/shub/__init__.py
+++ b/shub/__init__.py
@@ -1,1 +1,7 @@
 __version__ = '2.7.0'
+
+
+# Links to documentation to use over the project sources
+DOCS_LINK = "https://shub.readthedocs.io/en/stable/"
+DEPLOY_DOCS_LINK = DOCS_LINK + "deploying.html#deploying-dependencies"
+CONFIG_DOCS_LINK = DOCS_LINK + "configuration.html"

--- a/shub/config.py
+++ b/shub/config.py
@@ -8,6 +8,7 @@ import click
 import six
 import yaml
 
+from shub import DOCS_LINK, CONFIG_DOCS_LINK
 from shub.exceptions import (BadParameterException, BadConfigException,
                              ConfigParseException, MissingAuthException,
                              NotFoundException, ShubDeprecationWarning,
@@ -21,7 +22,6 @@ SH_IMAGES_REGISTRY = 'images.scrapinghub.com'
 SH_IMAGES_REPOSITORY = SH_IMAGES_REGISTRY + '/project/{project}'
 GLOBAL_SCRAPINGHUB_YML_PATH = os.path.expanduser("~/.scrapinghub.yml")
 NETRC_PATH = os.path.expanduser('~/_netrc' if os.name == 'nt' else '~/.netrc')
-CONFIG_DOCS_LINK = "https://shub.readthedocs.io/en/stable/configuration.html"
 
 
 class ShubConfig(object):
@@ -393,12 +393,12 @@ But no worries, shub has automatically migrated your global settings to
 ~/.scrapinghub.yml, and will also automatically migrate your project settings
 when you run a command within a Scrapy project.
 
-Visit http://doc.scrapinghub.com/shub.html for more information on the new
-configuration format and its benefits.
+Visit {docs_link} for more information on the new configuration format and
+its benefits.
 
 Happy scraping!
 -------------------------------------------------------------------------------
-"""
+""".format(docs_link=DOCS_LINK)
 
 
 def _migrate_to_global_scrapinghub_yml():
@@ -423,19 +423,19 @@ def _migrate_to_global_scrapinghub_yml():
 PROJECT_MIGRATION_OK_BANNER = """
 INFO: Your deploy configuration has been migrated to scrapinghub.yml.
 shub will no longer read from scrapy.cfg (but Scrapy will, so don't delete it).
-Visit http://doc.scrapinghub.com/shub.html for more information.
-"""
+Visit {docs_link} for more information.
+""".format(docs_link=DOCS_LINK)
 
 
 PROJECT_MIGRATION_FAILED_BANNER = """
 WARNING: shub failed to convert your scrapy.cfg to scrapinghub.yml. Please
-visit http://doc.scrapinghub.com/shub.html for help on how to use the new
-configuration format. We would be grateful if you could also file a bug report
-at https://github.com/scrapinghub/shub/issues
+visit {docs_link} for help on how to use the new configuration format. We
+would be grateful if you could also file a bug report at
+https://github.com/scrapinghub/shub/issues
 
 For now, shub fell back to reading from scrapy.cfg, everything should work as
 expected.
-"""
+""".format(docs_link=DOCS_LINK)
 
 
 def _migrate_and_load_scrapy_cfg(conf):

--- a/shub/deploy_egg.py
+++ b/shub/deploy_egg.py
@@ -4,7 +4,7 @@ import tempfile
 
 import click
 
-from shub import utils
+from shub import utils, DEPLOY_DOCS_LINK
 from shub.config import get_target_conf
 from shub.exceptions import (BadParameterException, NotFoundException,
                              SubcommandException)
@@ -46,8 +46,7 @@ SHORT_HELP = "[DEPRECATED] Build and deploy egg from source"
 def cli(target, from_url=None, git_branch=None, from_pypi=None):
     click.secho(
         "deploy-egg was deprecated, define the eggs you would like to deploy "
-        "in your scrapinghub.yml instead. See "
-        "http://doc.scrapinghub.com/shub.html#deploying-dependencies",
+        "in your scrapinghub.yml instead. See {}".format(DEPLOY_DOCS_LINK),
         err=True, fg='yellow',
     )
     main(target, from_url, git_branch, from_pypi)

--- a/shub/deploy_reqs.py
+++ b/shub/deploy_reqs.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 import shutil
 
+from shub import DEPLOY_DOCS_LINK
 from shub.config import get_target_conf
 from shub.utils import (build_and_deploy_eggs, decompress_egg_files,
                         download_from_pypi)
@@ -34,8 +35,7 @@ SHORT_HELP = "[DEPRECATED] Build and deploy eggs from requirements.txt"
 def cli(target, requirements_file):
     click.secho(
         "deploy-reqs was deprecated, define a requirements file in your "
-        "scrapinghub.yml instead. See "
-        "http://doc.scrapinghub.com/shub.html#deploying-dependencies",
+        "scrapinghub.yml instead. See {}".format(DEPLOY_DOCS_LINK),
         err=True, fg='yellow',
     )
     main(target, requirements_file)

--- a/tests/samples/deploy_egg_sample_project/setup.py
+++ b/tests/samples/deploy_egg_sample_project/setup.py
@@ -6,7 +6,6 @@ setup(
     name='test_project',
     version='1.2.0',
     packages=['test_project'],
-    url='https://doc.scrapinghub.com/test_project.html',
     description='Test Project',
     author='Scrapinghub',
     author_email='info@scrapinghub.com',


### PR DESCRIPTION
Some docs pointing to `docs.sh.com` are outdated, let's update it.