### PR TITLE
Add Pipfile support to shub deploy

### DIFF
--- a/docs/deploying.rst
+++ b/docs/deploying.rst
@@ -59,6 +59,22 @@ Note that this requirements file is an *extension* of the `Scrapy Cloud
 stack`_, and therefore should not contain packages that are already part of the
 stack, such as ``scrapy``.
 
+In case you use `pipenv`_ you may also specify a ``Pipfile``:
+
+    # project_directory/scrapinghub.yml
+
+    projects:
+      default: 12345
+      prod: 33333
+
+    requirements:
+      file: Pipfile
+
+In this case the ``Pipfile`` must be locked and ``pipenv`` available in the 
+environment. A requirements.txt file will be created out of the ``Pipfile``
+so like the requirements file above, it should not contain packages that are
+already part of the stack.
+
 When your dependencies cannot be specified in a requirements file, e.g.
 because they are not publicly available, you can supply them as Python eggs::
 
@@ -79,6 +95,8 @@ build your own Docker image to be used on Scrapy Cloud. See
 :ref:`deploy-custom-image`.
 
 .. _requirements file: https://pip.pypa.io/en/stable/user_guide/#requirements-files
+
+.. _pipenv: https://github.com/pypa/pipenv
 
 .. _choose-custom-stack:
 

--- a/shub/deploy.py
+++ b/shub/deploy.py
@@ -3,6 +3,7 @@ import os
 import glob
 import shutil
 import tempfile
+import json
 from six.moves.urllib.parse import urljoin
 
 import click
@@ -144,6 +145,8 @@ def _upload_egg(endpoint, eggpath, project, version, auth, verbose, keep_log,
 
     try:
         files = [('eggs', open(path, 'rb')) for path in expanded_eggs]
+        if _is_pipfile(requirements_file):
+            requirements_file = _get_pipfile_requirements()
         if requirements_file:
             files.append(('requirements', open(requirements_file, 'rb')))
     except IOError as e:
@@ -152,6 +155,23 @@ def _upload_egg(endpoint, eggpath, project, version, auth, verbose, keep_log,
     url = _url(endpoint, 'scrapyd/addversion.json')
     click.echo('Deploying to Scrapy Cloud project "%s"' % project)
     return make_deploy_request(url, data, files, auth, verbose, keep_log)
+
+
+def _is_pipfile(name):
+    return name in ['Pipfile', 'Pipfile.lock']
+
+
+def _get_pipfile_requirements():
+    try:
+        from pipenv.utils import convert_deps_to_pip
+    except ImportError:
+        raise ImportError('You need pipenv installed to deploy with Pipfile')
+    try:
+        with open('Pipfile.lock') as f:
+            deps = json.load(f)['default']
+    except IOError:
+        raise ShubException('Please lock your Pipfile before deploying')
+    return convert_deps_to_pip(deps)
 
 
 def _build_egg():

--- a/tests/requirements.in
+++ b/tests/requirements.in
@@ -2,3 +2,4 @@ mock
 pytest
 pytest-cov
 flake8
+pipenv

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -14,6 +14,7 @@ mccabe==0.6.1             # via flake8
 mock==2.0.0
 packaging==16.8           # via setuptools
 pbr==1.10.0               # via mock
+pipenv==11.10.1
 py==1.4.32                # via pytest
 pycodestyle==2.3.1        # via flake8
 pyflakes==1.5.0           # via flake8
@@ -21,6 +22,8 @@ pyparsing==2.1.10         # via packaging
 pytest-cov==2.4.0
 pytest==3.0.6
 six==1.10.0               # via mock, packaging, setuptools
+virtualenv-clone==0.3.0   # via pipenv
+virtualenv==15.2.0        # via pipenv
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools                # via pytest


### PR DESCRIPTION
As we talked on https://github.com/scrapinghub/shub/issues/312 this is a PR to add support to Pipfile on shub deploy.

This PR doesn't touch anything related to `shub image...` and simply uses pipenv internals to parse `Pipfile.lock` into a `requirements.txt` file.

I have opted to keep using `requirements_file` settings where if the user gives it the value of `Pipfile` or `Pipfile.lock` it tries to parse `Pipfile.lock`

If these changes are ok, I believe there will also be docs changes needed, please instruct me if that is the case.