### PR TITLE
Ignore hashes on Pipfile.lock to play nice with vcs packages

### DIFF
--- a/shub/deploy.py
+++ b/shub/deploy.py
@@ -174,6 +174,13 @@ def _get_pipfile_requirements():
             deps = json.load(f)['default']
     except IOError:
         raise ShubException('Please lock your Pipfile before deploying')
+    # We must remove any hash from the pipfile before converting to play nice
+    # with vcs packages
+    for k, v in deps.items():
+        if 'hash' in v:
+            del v['hash']
+        if 'hashes' in v:
+            del v['hashes']
     return convert_deps_to_pip(deps)
 
 

--- a/shub/deploy.py
+++ b/shub/deploy.py
@@ -181,6 +181,9 @@ def _get_pipfile_requirements():
             del v['hash']
         if 'hashes' in v:
             del v['hashes']
+        # Scrapy Cloud also doesn't support editable packages
+        if 'editable' in v:
+            del v['editable']
     return convert_deps_to_pip(deps)
 
 

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -274,7 +274,8 @@ class DeployFilesTest(unittest.TestCase):
                         },
                         "vcs-package": {
                             "git": "https://github.com/vcs/package.git",
-                            "ref": "master"
+                            "ref": "master",
+                            "editable": true
                         }
                     }
                 }

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -253,7 +253,7 @@ class DeployFilesTest(unittest.TestCase):
         self.assertEqual(len(files_main['eggs']), 4)
         self.assertIn('main content', files_main['eggs'])
 
-    def pipefile_test(self, req_name):
+    def pipfile_test(self, req_name):
         with self.runner.isolated_filesystem():
             with open('./main.egg', 'w') as f:
                 f.write('main content')
@@ -263,6 +263,18 @@ class DeployFilesTest(unittest.TestCase):
                     "default": {
                         "package": {
                             "version": "==0.0.0"
+                        },
+                        "hash-package": {
+                            "version": "==0.0.1",
+                            "hash": "hash"
+                        },
+                        "hash-package2": {
+                            "version": "==0.0.1",
+                            "hashes": ["hash1", "hash2"]
+                        },
+                        "vcs-package": {
+                            "git": "https://github.com/vcs/package.git",
+                            "ref": "master"
                         }
                     }
                 }
@@ -273,13 +285,19 @@ class DeployFilesTest(unittest.TestCase):
                 f.write('2.egg content')
             files = self._deploy(req=req_name)
 
-        self.assertEqual(files['requirements'][0], 'package==0.0.0')
+        reqs = set(files['requirements'][0].split('\n'))
+        self.assertEqual(reqs, {
+            'package==0.0.0',
+            'hash-package==0.0.1',
+            'hash-package2==0.0.1',
+            'git+https://github.com/vcs/package.git@master#egg=vcs-package',
+        })
 
-    def test_pipefile_namess(self):
-        self.pipefile_test('Pipfile')
-        self.pipefile_test('Pipfile.lock')
+    def test_pipfile_names(self):
+        self.pipfile_test('Pipfile')
+        self.pipfile_test('Pipfile.lock')
 
-    def test_pipefile_lock_missing(self):
+    def test_pipfile_lock_missing(self):
         with self.runner.isolated_filesystem():
             with open('./main.egg', 'w') as f:
                 f.write('main content')


### PR DESCRIPTION
Fixes https://github.com/scrapinghub/shub/issues/317

VCS packages don't generate hashes, and `convert_deps_to_pip` generates requirements with hashes.

When we run `pip install -r requirements.txt` with a `requirements.txt` like:
```
package==1.0 --hash=hash
git+https://github... # note that it doesn't have the --hash
```
It fails since the vcs package can't be hashed

Thus we must delete these hashes from the object before giving it to `convert_deps_to_pip`

Btw, they do something similar in their own code: https://github.com/pypa/pipenv/blob/master/pipenv/utils.py#L793