### PR TITLE
Remove use of Py3.7 reserved word

### DIFF
--- a/shub/image/deploy.py
+++ b/shub/image/deploy.py
@@ -55,16 +55,16 @@ Does a simple POST request to Dash API with given parameters
 @click.option("--email", help="docker registry email")
 @click.option("--apikey", help="SH apikey to use built-in registry")
 @click.option("--insecure", is_flag=True, help="use insecure registry")
-@click.option("--async", is_flag=True, help="[DEPRECATED] enable asynchronous mode",
+@click.option("--async", "_async", is_flag=True, help="[DEPRECATED] enable asynchronous mode",
               callback=utils.deprecate_async_parameter)
 def cli(target, debug, verbose, version, username, password, email,
-        apikey, insecure, async):
+        apikey, insecure, _async):
     deploy_cmd(target, version, username, password, email,
-               apikey, insecure, async)
+               apikey, insecure, _async)
 
 
 def deploy_cmd(target, version, username, password, email,
-               apikey, insecure, async):
+               apikey, insecure, _async):
     config = load_shub_config()
     target_conf = config.get_target_conf(target)
     endpoint, target_apikey = target_conf.endpoint, target_conf.apikey
@@ -99,7 +99,7 @@ def deploy_cmd(target, version, username, password, email,
     click.echo(
         "You can check deploy results later with "
         "'shub image check --id {}'.".format(status_id))
-    if async:
+    if _async:
         return
     if utils.is_verbose():
         deploy_progress_cls = _LoggedDeployProgress

--- a/shub/image/deploy.py
+++ b/shub/image/deploy.py
@@ -55,16 +55,16 @@ Does a simple POST request to Dash API with given parameters
 @click.option("--email", help="docker registry email")
 @click.option("--apikey", help="SH apikey to use built-in registry")
 @click.option("--insecure", is_flag=True, help="use insecure registry")
-@click.option("--async", "_async", is_flag=True, help="[DEPRECATED] enable asynchronous mode",
+@click.option("--async", "async_", is_flag=True, help="[DEPRECATED] enable asynchronous mode",
               callback=utils.deprecate_async_parameter)
 def cli(target, debug, verbose, version, username, password, email,
-        apikey, insecure, _async):
+        apikey, insecure, async_):
     deploy_cmd(target, version, username, password, email,
-               apikey, insecure, _async)
+               apikey, insecure, async_)
 
 
 def deploy_cmd(target, version, username, password, email,
-               apikey, insecure, _async):
+               apikey, insecure, async_):
     config = load_shub_config()
     target_conf = config.get_target_conf(target)
     endpoint, target_apikey = target_conf.endpoint, target_conf.apikey
@@ -99,7 +99,7 @@ def deploy_cmd(target, version, username, password, email,
     click.echo(
         "You can check deploy results later with "
         "'shub image check --id {}'.".format(status_id))
-    if _async:
+    if async_:
         return
     if utils.is_verbose():
         deploy_progress_cls = _LoggedDeployProgress

--- a/shub/image/upload.py
+++ b/shub/image/upload.py
@@ -31,23 +31,23 @@ Obviously it accepts all the options for the commands above.
 @click.option("--email", help="docker registry email")
 @click.option("--apikey", help="SH apikey to use built-in registry")
 @click.option("--insecure", is_flag=True, help="use insecure registry")
-@click.option("--async", "_async", is_flag=True, help="[DEPRECATED] enable asynchronous mode",
+@click.option("--async", "async_", is_flag=True, help="[DEPRECATED] enable asynchronous mode",
               callback=utils.deprecate_async_parameter)
 @click.option("-S", "--skip-tests", help="skip testing image", is_flag=True)
 @click.option("-f", "--file", "filename", default='Dockerfile',
               help="Name of the Dockerfile (Default is 'PATH/Dockerfile')")
 def cli(target, debug, verbose, version, username, password, email,
-        apikey, insecure, _async, skip_tests, filename):
+        apikey, insecure, async_, skip_tests, filename):
     upload_cmd(target, version, username, password, email, apikey, insecure,
-               _async, skip_tests, filename)
+               async_, skip_tests, filename)
 
 
 def upload_cmd(target, version, username=None, password=None, email=None,
-               apikey=None, insecure=False, _async=False, skip_tests=False,
+               apikey=None, insecure=False, async_=False, skip_tests=False,
                filename='Dockerfile'):
     build.build_cmd(target, version, skip_tests, filename=filename)
     # skip tests for push command anyway because they run in build command if not skipped
     push.push_cmd(target, version, username, password, email, apikey,
                   insecure, skip_tests=True)
     deploy.deploy_cmd(target, version, username, password, email,
-                      apikey, insecure, _async)
+                      apikey, insecure, async_)

--- a/shub/image/upload.py
+++ b/shub/image/upload.py
@@ -31,23 +31,23 @@ Obviously it accepts all the options for the commands above.
 @click.option("--email", help="docker registry email")
 @click.option("--apikey", help="SH apikey to use built-in registry")
 @click.option("--insecure", is_flag=True, help="use insecure registry")
-@click.option("--async", is_flag=True, help="[DEPRECATED] enable asynchronous mode",
+@click.option("--async", "_async", is_flag=True, help="[DEPRECATED] enable asynchronous mode",
               callback=utils.deprecate_async_parameter)
 @click.option("-S", "--skip-tests", help="skip testing image", is_flag=True)
 @click.option("-f", "--file", "filename", default='Dockerfile',
               help="Name of the Dockerfile (Default is 'PATH/Dockerfile')")
 def cli(target, debug, verbose, version, username, password, email,
-        apikey, insecure, async, skip_tests, filename):
+        apikey, insecure, _async, skip_tests, filename):
     upload_cmd(target, version, username, password, email, apikey, insecure,
-               async, skip_tests, filename)
+               _async, skip_tests, filename)
 
 
 def upload_cmd(target, version, username=None, password=None, email=None,
-               apikey=None, insecure=False, async=False, skip_tests=False,
+               apikey=None, insecure=False, _async=False, skip_tests=False,
                filename='Dockerfile'):
     build.build_cmd(target, version, skip_tests, filename=filename)
     # skip tests for push command anyway because they run in build command if not skipped
     push.push_cmd(target, version, username, password, email, apikey,
                   insecure, skip_tests=True)
     deploy.deploy_cmd(target, version, username, password, email,
-                      apikey, insecure, async)
+                      apikey, insecure, _async)


### PR DESCRIPTION
`async` is a reserved word in Python 3.7 (https://docs.python.org/3.7/reference/lexical_analysis.html#keywords) and `shub` uses it as a variable.

This PR closes #325 and remove the use of this reserved word, avoiding SyntaxError when running in Python 3.7.