### PR TITLE
Fix #331, use DOCKER_API_VERSION instead of DOCKER_VERSION

### DIFF
--- a/shub/image/utils.py
+++ b/shub/image/utils.py
@@ -96,7 +96,7 @@ def get_docker_client(validate=True):
             verify=apply_path_fun('ca.pem'),
             assert_hostname=False)
         docker_host = docker_host.replace('tcp://', 'https://')
-    version = os.environ.get('DOCKER_VERSION', DEFAULT_DOCKER_VERSION)
+    version = os.environ.get('DOCKER_API_VERSION', DEFAULT_DOCKER_VERSION)
     client = docker_client_cls(base_url=docker_host,
                                version=version,
                                tls=tls_config)

--- a/shub/image/utils.py
+++ b/shub/image/utils.py
@@ -15,7 +15,7 @@ from shub.exceptions import (
 )
 
 
-DEFAULT_DOCKER_VERSION = '1.17'
+DEFAULT_DOCKER_API_VERSION = '1.17'
 STATUS_FILE_LOCATION = '.releases'
 _VALIDSPIDERNAME = re.compile('^[a-z0-9][-._a-z0-9]+$', re.I)
 
@@ -96,7 +96,7 @@ def get_docker_client(validate=True):
             verify=apply_path_fun('ca.pem'),
             assert_hostname=False)
         docker_host = docker_host.replace('tcp://', 'https://')
-    version = os.environ.get('DOCKER_API_VERSION', DEFAULT_DOCKER_VERSION)
+    version = os.environ.get('DOCKER_API_VERSION', DEFAULT_DOCKER_API_VERSION)
     client = docker_client_cls(base_url=docker_host,
                                version=version,
                                tls=tls_config)

--- a/tests/image/test_utils.py
+++ b/tests/image/test_utils.py
@@ -47,7 +47,7 @@ class ReleaseUtilsTest(TestCase):
             base_url=None, tls=None, version='1.17')
         # set basic test environment
         os.environ['DOCKER_HOST'] = 'http://127.0.0.1'
-        os.environ['DOCKER_VERSION'] = '1.18'
+        os.environ['DOCKER_API_VERSION'] = '1.18'
         assert get_docker_client()
         client_mock.assert_called_with(
             base_url='http://127.0.0.1', tls=None, version='1.18')


### PR DESCRIPTION
Fix #331, use DOCKER_API_VERSION instead of DOCKER_VERSION