### PR TITLE
Use scrapinghub.ScrapinghubClient

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -6,4 +6,4 @@ retrying
 six
 tqdm
 
-scrapinghub>=1.9.0
+scrapinghub>=2.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ ipaddress==1.0.17         # via docker-py
 pyyaml==3.12
 requests==2.10.0
 retrying==1.3.3
-scrapinghub==1.9.0
+scrapinghub==2.0.3
 six==1.10.0
 tqdm==4.11.2
 websocket-client==0.37.0  # via docker-py

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         'PyYAML',
         'retrying',
         'requests',
-        'scrapinghub>=1.9.0',
+        'scrapinghub>=2.0.3',
         'six>=1.7.0',
         'tqdm',
     ],

--- a/shub/utils.py
+++ b/shub/utils.py
@@ -29,13 +29,7 @@ try:
 except:
     from pip._internal import main as pip_main
 
-from scrapinghub import Connection, APIError
-
-try:
-    from scrapinghub import HubstorageClient
-except ImportError:
-    # scrapinghub < 1.9.0
-    from hubstorage import HubstorageClient
+from scrapinghub import ScrapinghubClient, ScrapinghubAPIError, HubstorageClient
 
 import shub
 from shub.compat import to_native_str
@@ -672,10 +666,10 @@ def has_project_access(project, endpoint, apikey):
     """Check whether an API key has access to a given project. May raise
     InvalidAuthException if the API key is invalid (but not if it is valid but
     lacks access to the project)"""
-    conn = Connection(apikey, url=endpoint)
+    client = ScrapinghubClient(apikey, dash_endpoint=endpoint)
     try:
-        return project in conn.project_ids()
-    except APIError as e:
+        return project in client.projects.list()
+    except ScrapinghubAPIError as e:
         if 'Authentication failed' in str(e):
             raise InvalidAuthException
         else:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,7 +17,7 @@ import yaml
 from click.testing import CliRunner
 from collections import deque
 from mock import Mock, MagicMock, patch
-from scrapinghub import APIError
+from scrapinghub import ScrapinghubAPIError
 
 from shub import utils
 from shub.config import ShubConfig
@@ -464,13 +464,13 @@ class UtilsTest(AssertInvokeRaisesMixin, unittest.TestCase):
             result = runner.invoke(call_update_yaml_dict)
         assert 'deprecated' in result.output
 
-    @patch('shub.utils.Connection')
-    def test_has_project_access(self, mock_conn):
-        mock_conn.return_value.project_ids.side_effect = APIError(
+    @patch('shub.utils.ScrapinghubClient')
+    def test_has_project_access(self, mock_client):
+        mock_client.return_value.projects.list.side_effect = ScrapinghubAPIError(
             'Authentication failed')
         with self.assertRaises(InvalidAuthException):
             utils.has_project_access(12345, 'mock_endpoint', 'abcdef')
-        mock_conn.return_value.project_ids.side_effect = APIError(
+        mock_client.return_value.projects.list.side_effect = ScrapinghubAPIError(
             'Random error')
         with self.assertRaises(RemoteErrorException):
             utils.has_project_access(12345, 'mock_endpoint', 'abcdef')


### PR DESCRIPTION
Instead of the legacy `scrapinghub.Connection` class.

This time I did try scheduling spiders with default unit amounts set in Dash and it works :sweat_smile: (#329) 