### PR TITLE
Check for custom image size before push

### DIFF
--- a/shub/exceptions.py
+++ b/shub/exceptions.py
@@ -75,6 +75,12 @@ class DeployRequestTooLargeException(ShubException):
                    "project egg(s) size is less than 50MB in total.")
 
 
+class CustomImageTooLargeException(ShubException):
+    exit_code = 65  # EX_DATAERR
+    default_msg = ("Custom Docker image is too large. Please make sure that "
+                   "your image size is less than 3GB.")
+
+
 class ShubWarning(Warning):
     """Base class for custom warnings."""
 


### PR DESCRIPTION
The idea is to extend one of the existing checks to ensure that the custom image is not more than 3GB, before pushing it, otherwise raise a warning. At least it should prevent deploying huge images blindly.

Requesting to review the warning message mainly.