### PR TITLE
Add option to run job with custom envvars

### DIFF
--- a/shub/schedule.py
+++ b/shub/schedule.py
@@ -48,11 +48,13 @@ DEFAULT_PRIORITY = 2
               help='Job-specific setting (-s name=value)', multiple=True)
 @click.option('-p', '--priority', type=int, default=DEFAULT_PRIORITY,
               help='Job priority (-p number). From 0 (lowest) to 4 (highest)')
+@click.option('-e', '--environment', multiple=True,
+              help='Job environment variable (-e VAR=VAL)')
 @click.option('-u', '--units', type=int,
               help='Amount of Scrapy Cloud units (-u number)')
 @click.option('-t', '--tag',
               help='Job tags (-t tag)', multiple=True)
-def cli(spider, argument, set, priority, units, tag):
+def cli(spider, argument, set, environment, priority, units, tag):
     try:
         target, spider = spider.rsplit('/', 1)
     except ValueError:
@@ -60,7 +62,7 @@ def cli(spider, argument, set, priority, units, tag):
     targetconf = get_target_conf(target)
     job_key = schedule_spider(targetconf.project_id, targetconf.endpoint,
                               targetconf.apikey, spider, argument, set,
-                              priority, units, tag)
+                              priority, units, tag, environment)
     watch_url = urljoin(
         targetconf.endpoint,
         '../p/{}/{}/{}'.format(*job_key.split('/')),
@@ -76,7 +78,7 @@ def cli(spider, argument, set, priority, units, tag):
 
 
 def schedule_spider(project, endpoint, apikey, spider, arguments=(), settings=(),
-                    priority=DEFAULT_PRIORITY, units=None, tag=()):
+                    priority=DEFAULT_PRIORITY, units=None, tag=(), environment=()):
     client = ScrapinghubClient(apikey, dash_endpoint=endpoint)
     try:
         project = client.get_project(project)
@@ -92,6 +94,7 @@ def schedule_spider(project, endpoint, apikey, spider, arguments=(), settings=()
             priority=priority,
             units=units,
             add_tag=tag,
+            environment=json.dumps(dict(x.split('=', 1) for x in environment)),
         )
         return job.key
     except ScrapinghubAPIError as e:

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -25,20 +25,20 @@ class ScheduleTest(unittest.TestCase):
         # Default
         self.runner.invoke(schedule.cli, ['spider'])
         mock_schedule.assert_called_with(
-            proj, endpoint, apikey, 'spider', (), (), 2, None, ())
+            proj, endpoint, apikey, 'spider', (), (), 2, None, (), ())
         # Other project
         self.runner.invoke(schedule.cli, ['123/spider'])
         mock_schedule.assert_called_with(
-            123, endpoint, apikey, 'spider', (), (), 2, None, ())
+            123, endpoint, apikey, 'spider', (), (), 2, None, (), ())
         # Other endpoint
         proj, endpoint, apikey = self.conf.get_target('vagrant')
         self.runner.invoke(schedule.cli, ['vagrant/spider'])
         mock_schedule.assert_called_with(
-            proj, endpoint, apikey, 'spider', (), (), 2, None, ())
+            proj, endpoint, apikey, 'spider', (), (), 2, None, (), ())
         # Other project at other endpoint
         self.runner.invoke(schedule.cli, ['vagrant/456/spider'])
         mock_schedule.assert_called_with(
-            456, endpoint, apikey, 'spider', (), (), 2, None, ())
+            456, endpoint, apikey, 'spider', (), (), 2, None, (), ())
 
     @mock.patch('shub.schedule.ScrapinghubClient', autospec=True)
     def test_schedule_invalid_spider(self, mock_client):
@@ -108,6 +108,20 @@ class ScheduleTest(unittest.TestCase):
         self.runner.invoke(schedule.cli, 'testspider --units 3'.split())
         call_kwargs = mock_proj.jobs.run.call_args[1]
         assert call_kwargs['units'] == 3
+
+    @mock.patch('shub.schedule.Connection', autospec=True)
+    def test_forwards_environment(self, mock_conn):
+        mock_proj = mock_conn.return_value.__getitem__.return_value
+        self.runner.invoke(
+            schedule.cli,
+            "testspider -e VAR1=VAL1 --environment VAR2=VAL2".split(' '),
+        )
+        call_kwargs = mock_proj.schedule.call_args[1]
+        # SH API expects environment as json-encoded string named 'environment'
+        self.assertDictContainsSubset(
+            {'VAR1': 'VAL1', 'VAR2': 'VAL2'},
+            json.loads(call_kwargs['environment']),
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
SC backend now supports passing custom environment variables when scheduling jobs, the PR adds appropriate changes to support it on the CLI level.