### PR TITLE
Add a command to run custom image locally

### DIFF
--- a/shub/image/__init__.py
+++ b/shub/image/__init__.py
@@ -16,6 +16,7 @@ module_deps = [
     "deploy",
     "upload",
     "check",
+    "run",
 ]
 
 for command in module_deps:

--- a/shub/image/run/__init__.py
+++ b/shub/image/run/__init__.py
@@ -1,0 +1,141 @@
+import json
+import stat
+import shlex
+import signal
+import os.path
+from os import stat as os_stat
+from shutil import copyfile
+
+import click
+
+from shub.config import load_shub_config
+from shub.image import utils
+
+
+SHORT_HELP = 'Run custom image locally.'
+HELP = """
+Run a custom Docker image locally.
+
+The command should be helpful to ensure that your custom image is properly
+written and do some preliminary local tests before pushing it to Scrapy Cloud.
+
+Most of the command parameters coincide with parameters for 'shub schedule'
+command to simplfy its usage.
+
+The `spider` argument should match the spider's name, e.g.:
+
+    shub image run myspider
+
+A more advanced example of using non-default target with settings/arguments:
+
+    shub image run production/myspider -a ARG1=VAL1 -s LOG_LEVEL=DEBUG
+"""
+
+SCRAPINGHUB_VOLUME = '/scrapinghub'
+WRAPPER_FILENAME = 'start-crawl-local'
+WRAPPER_LOCAL_PATH = os.path.join(os.path.dirname(__file__), 'wrapper.py')
+WRAPPER_IMAGE_PATH = os.path.join(SCRAPINGHUB_VOLUME, WRAPPER_FILENAME)
+
+
+@click.command(help=HELP, short_help=SHORT_HELP)
+@click.argument("spider", type=click.STRING)
+@click.option('-a', '--argument', 'args',
+              help='Spider argument (-a name=value)', multiple=True)
+@click.option('-s', '--set', 'settings',
+              help='Job-specific setting (-s name=value)', multiple=True)
+@click.option('-e', '--environment', multiple=True,
+              help='Job environment variable (-e VAR=VAL)')
+@click.option("-V", "--version", help="use custom release version")
+@click.option("-v", "--verbose", is_flag=True,
+              help="stream additional logs to console")
+@click.option("-k", "--keep-volume", help="Keep volume folder", is_flag=True)
+def cli(spider, args, settings, environment, version, verbose, keep_volume):
+    run_cmd(spider, args, settings, environment, version, keep_volume)
+
+
+def run_cmd(spider, args, settings, environment, version, keep_volume):
+    try:
+        target, spider = spider.rsplit('/', 1)
+    except ValueError:
+        target = 'default'
+
+    config = load_shub_config()
+    image = config.get_image(target)
+    version = version or config.get_version()
+    image_name = utils.format_image_name(image, version)
+    docker_client = utils.get_docker_client()
+
+    env = _format_environment(spider, args, settings, environment)
+    _run_with_docker(docker_client, image_name, env, keep_volume)
+
+
+def _format_environment(spider, args, settings, environment):
+    """Convert all input crawl args to environment variables."""
+    # required defaults, can be overwritten with meta if needed
+    job_data = {'spider': spider, 'key': '1/2/3', 'auth': '<auth>'}
+
+    args = dict(x.split('=', 1) for x in args)
+    cmd_args = shlex.split(args.pop('cmd_args', ''))
+    if spider.startswith('py:'):
+        job_data['job_cmd'] = [spider] + cmd_args
+    else:
+        job_data['spider_args'] = args
+    meta = args.pop('meta', None)
+    if meta:
+        job_data.update(json.loads(meta))
+
+    job_environment = dict(x.split('=', 1) for x in environment)
+    job_settings = dict(x.split('=', 1) for x in settings)
+    return {
+        'SHUB_JOBKEY': job_data['key'],
+        'SHUB_SPIDER': spider,
+        'SHUB_JOB_DATA': _json_dumps(job_data),
+        'SHUB_JOB_ENV': _json_dumps(job_environment),
+        'SHUB_SETTINGS': _json_dumps({'job_settings': job_settings}),
+        'PYTHONUNBUFFERED': 1,
+    }
+
+
+def _json_dumps(data):
+    return json.dumps(data, sort_keys=True, separators=(',', ':'))
+
+
+def _run_with_docker(client, image_name, env, keep_volume=False):
+    """Run a local docker container with the given custom image."""
+
+    def _signal_handler(sig, _):
+        client.kill(container, sig)
+
+    tmpdir_kw = {'prefix': 'shub-image-run-', 'cleanup': not keep_volume}
+    with utils.make_temp_directory(**tmpdir_kw) as volume_dir:
+        container = _create_container(client, image_name, env, volume_dir)
+        try:
+            client.start(container)
+            signal.signal(signal.SIGINT, _signal_handler)
+            signal.signal(signal.SIGTERM, _signal_handler)
+            for log in client.logs(container, stream=True):
+                click.echo(log.rstrip())
+        finally:
+            client.remove_container(container, force=True)
+
+
+def _create_container(client, image_name, environment, volume_dir):
+    """Create a docker container and customize its setup."""
+    # copy start-crawl wrapper to the volume temporary directory
+    wrapper_cont_path = os.path.join(volume_dir, WRAPPER_FILENAME)
+    copyfile(WRAPPER_LOCAL_PATH, wrapper_cont_path)
+    wrapper_perms = os_stat(wrapper_cont_path).st_mode | stat.S_IEXEC
+    os.chmod(wrapper_cont_path, wrapper_perms)  # must be executable
+    fifo_path = os.path.join(volume_dir, 'scrapinghub.fifo')
+    environment['SHUB_FIFO_PATH'] = fifo_path
+    # keep using default /scrapinghub volume but mount it as a temporary
+    # directory in the host /tmp/ to have access to the files in needed
+    binds = {volume_dir: {'bind': SCRAPINGHUB_VOLUME, 'mode': 'rw'}}
+    host_config = client.create_host_config(binds=binds)
+    return client.create_container(
+        image=image_name,
+        command=[WRAPPER_IMAGE_PATH],
+        environment=environment,
+        volumes=[volume_dir],
+        host_config=host_config,
+    )

--- a/shub/image/run/wrapper.py
+++ b/shub/image/run/wrapper.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+"""
+A helper wrapper over start-crawl to run a custom image locally.
+
+The wrapper is used in `shub image run` command as an entrypoint
+to create a FIFO file inside a Docker container, enforce using it
+to communicate with crawl process and start the crawl process.
+
+The initial version handles and prints only LOG entries to mimic
+Scrapy behavior when running locally, however it could be easily
+extended in the future.
+
+Reading about SH custom image contract should bring you more context
+https://shub.readthedocs.io/en/stable/custom-images-contract.html.
+
+FIFO based communication protocol is described well in
+https://doc.scrapinghub.com/scrapy-cloud-write-entrypoint.html
+
+TODO As a custom image isn't necessarily based on Python, the wrapper
+should be rewritten in the future with something more basic and
+lightweight, to get rid of dependence on Python.
+"""
+
+from __future__ import print_function
+
+import os
+import sys
+import json
+import logging
+import datetime
+from multiprocessing import Process
+from distutils.spawn import find_executable
+
+
+def _consume_from_fifo(fifo_path):
+    """Start reading/printing entries from FIFO."""
+    with open(fifo_path) as fifo:
+        while True:
+            line = fifo.readline()
+            # returns an empty string only in the end of the file
+            if not line:
+                return
+            entry_type, entry_raw = line[:3], line[4:]
+            _print_fifo_entry(entry_type, json.loads(entry_raw))
+
+
+def _print_fifo_entry(message_type, message):
+    """Print only specific entries."""
+    if message_type == 'LOG':
+        timestamp = _millis_to_str(message['time'])
+        loglevel = logging.getLevelName(message['level'])
+        # mimic Scrapy logging format as much as possible
+        print('{} {} {}'.format(timestamp, loglevel, message['message']))
+
+
+def _millis_to_str(millis):
+    """Convert a datatime in ms to a formatted string."""
+    datetime_ts = datetime.datetime.fromtimestamp(millis / 1000.0)
+    return datetime_ts.strftime('%Y-%m-%d %H:%M:%S')
+
+
+def main():
+    """Main wrapper entrypoint."""
+    # create a named pipe for communication
+    fifo_path = os.environ.get('SHUB_FIFO_PATH')
+    os.mkfifo(fifo_path)
+    # create and start a consumer process to read from the fifo:
+    # non-daemon to allow it to finish reading from pipe before exit.
+    Process(target=_consume_from_fifo, args=[fifo_path]).start()
+    # replace current process with original start-crawl
+    os.execv(find_executable('start-crawl'), sys.argv)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/shub/image/utils.py
+++ b/shub/image/utils.py
@@ -1,6 +1,9 @@
 import os
 import re
 import sys
+import shutil
+import tempfile
+import contextlib
 
 import click
 import yaml
@@ -288,3 +291,13 @@ def create_progress_bar(total, desc, **kwargs):
         miniters=1,
         **kwargs
     )
+
+
+@contextlib.contextmanager
+def make_temp_directory(cleanup=True, **kwargs):
+    temp_dir = tempfile.mkdtemp(**kwargs)
+    try:
+        yield temp_dir
+    finally:
+        if cleanup:
+            shutil.rmtree(temp_dir)

--- a/tests/image/test_run.py
+++ b/tests/image/test_run.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+import os.path
+import tempfile
+
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
+import mock
+import pytest
+from click.testing import CliRunner
+
+from shub.image.run import cli, _json_dumps, WRAPPER_IMAGE_PATH
+from shub.image.run.wrapper import _consume_from_fifo
+from shub.image.utils import make_temp_directory
+
+
+def _format_job_data(spider='spider', auth='<auth>', **kwargs):
+    data = {'key': '1/2/3', 'spider': spider, 'auth': auth}
+    data.update(kwargs)
+    return _json_dumps(data)
+
+
+@pytest.mark.usefixtures('project_dir')
+def test_cli(docker_client_mock):
+    docker_client_mock.create_host_config.return_value = {'host': 'config'}
+    docker_client_mock.create_container.return_value = 'contID'
+    docker_client_mock.logs.return_value = ['some', 'logs']
+    # wrap make_temp_directory to validate its call args
+    tmp_dir_fun = 'shub.image.utils.make_temp_directory'
+    with mock.patch(tmp_dir_fun, wraps=make_temp_directory) as tmp_dir_mock:
+        result = CliRunner().invoke(cli, ["dev/spider"])
+    assert result.exit_code == 0, result.stdout
+    assert tmp_dir_mock.call_args[1] == {
+        'prefix': 'shub-image-run-', 'cleanup': True
+    }
+    docker_client_mock.start.assert_called_with('contID')
+    docker_client_mock.logs.assert_called_with('contID', stream=True)
+    docker_client_mock.remove_container.assert_called_with('contID', force=True)
+    # validate create_container args
+    docker_client_mock.create_container.assert_called_once()
+    call_args = docker_client_mock.create_container.call_args[1]
+    assert call_args['command'] == [WRAPPER_IMAGE_PATH]
+    # validate environment
+    call_env = call_args['environment']
+    fifo_path = call_env.pop('SHUB_FIFO_PATH')
+    assert fifo_path.endswith('scrapinghub.fifo')
+    job_data = _format_job_data(spider_args={})
+    expected_env = {
+        'SHUB_JOBKEY': '1/2/3',
+        'SHUB_SPIDER': 'spider',
+        'SHUB_JOB_DATA': job_data,
+        'SHUB_JOB_ENV': '{}',
+        'SHUB_SETTINGS': '{"job_settings":{}}',
+        'PYTHONUNBUFFERED': 1,
+    }
+    assert call_env == expected_env
+    # validate other configuration parts
+    assert call_args['host_config'] == {'host': 'config'}
+    assert call_args['image'] == 'registry.io/user/project:1.0'
+    assert call_args['volumes'] == [os.path.dirname(fifo_path)]
+
+
+@pytest.mark.usefixtures('project_dir')
+def test_cli_with_args(docker_client_mock):
+    docker_client_mock.logs.return_value = []
+    result = CliRunner().invoke(cli, (
+        'dev/spider -a arg0= -a arg1=val1 --argument arg2=val2 '
+        '-s SET1=VAL1 --set SET2=VAL2 '
+        '-e ENV1=ENVVAL1 --environment ENV2=ENVVAL2 '
+        '-a meta={"auth":"custom"}'.split(' ')
+    ))
+    assert result.exit_code == 0, result.stdout
+    call_args = docker_client_mock.create_container.call_args[1]
+    call_env = call_args['environment']
+    expected_settings = {"job_settings": {"SET1": "VAL1", "SET2": "VAL2"}}
+    assert call_env['SHUB_SETTINGS'] == _json_dumps(expected_settings)
+    expected_env = {"ENV1": "ENVVAL1", "ENV2": "ENVVAL2"}
+    assert call_env['SHUB_JOB_ENV'] == _json_dumps(expected_env)
+    expected_jobdata = {"arg0": "", "arg1": "val1", "arg2": "val2"}
+    assert call_env['SHUB_JOB_DATA'] == _format_job_data(
+        spider_args=expected_jobdata, auth='custom'
+    )
+
+
+@pytest.mark.usefixtures('project_dir')
+def test_cli_with_version(docker_client_mock):
+    docker_client_mock.logs.return_value = []
+    result = CliRunner().invoke(cli, ['dev/spider', '-V', 'custom'])
+    assert result.exit_code == 0, result.stdout
+    call_args = docker_client_mock.create_container.call_args[1]
+    assert call_args['image'] == 'registry.io/user/project:custom'
+
+
+@pytest.mark.usefixtures('project_dir')
+def test_cli_with_script(docker_client_mock):
+    docker_client_mock.logs.return_value = []
+    script_args = "--flag1 --flag2=0 val1 val2"
+    result = CliRunner().invoke(cli, [
+        'dev/py:testargs.py', '-a', 'cmd_args="%s"' % script_args
+    ])
+    assert result.exit_code == 0, result.stdout
+    call_args = docker_client_mock.create_container.call_args[1]
+    call_env = call_args['environment']
+    assert call_env['SHUB_JOB_DATA'] == _format_job_data(
+        spider='py:testargs.py',
+        job_cmd=["py:testargs.py", script_args],
+    )
+
+
+# Separate section for wrapper tests.
+
+FIFO_TEST_DATA = """\
+LOG {"time": 1485269941065, "level": 20, "message": "Some message"}
+ITM {"key": "value", "should-be": "ignored"}
+LOG {"time": 1485269941065, "level": 30, "message": "Other message"}\
+"""
+
+
+@mock.patch('sys.stdout', new_callable=StringIO)
+def test_consume_from_fifo(mock_stdout):
+    try:
+        # XXX work-around to use NamedTemporaryFile on Windows
+        # https://github.com/appveyor/ci/issues/2547
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as temp:
+            filename = temp.name
+            temp.write(FIFO_TEST_DATA)
+            temp.seek(0)
+            _consume_from_fifo(filename)
+    finally:
+        os.remove(filename)
+    assert mock_stdout.getvalue() == (
+        '2017-01-24 14:59:01 INFO Some message\n'
+        '2017-01-24 14:59:01 WARNING Other message\n'
+    )


### PR DESCRIPTION
We want to have a separate command to be able to run a custom image locally, for test/debugging purposes. The idea is to mimic (though simplify) SC approach by using a separate wrapper to read crawl process results from FIFO and print it to container stdout. The wrapper is written in Python for simplicity, but could be rewritten with anything more basic (like Bash) in the future.