### PR TITLE
Add "no-cache" option on "shub image build" command

### DIFF
--- a/shub/image/build.py
+++ b/shub/image/build.py
@@ -39,13 +39,15 @@ BUILD_SUCCESS_REGEX = re.compile(r'Successfully built ([0-9a-f]+)')
               help="stream build logs to console")
 @click.option("-V", "--version", help="release version")
 @click.option("-S", "--skip-tests", help="skip testing image", is_flag=True)
+@click.option("-n", "--no-cache", is_flag=True,
+              help="Do not use cache when building the image")
 @click.option("-f", "--file", "filename", default='Dockerfile',
               help="Name of the Dockerfile (Default is 'PATH/Dockerfile')")
-def cli(target, debug, verbose, version, skip_tests, filename):
-    build_cmd(target, version, skip_tests, filename=filename)
+def cli(target, debug, verbose, version, skip_tests, no_cache, filename):
+    build_cmd(target, version, skip_tests, no_cache, filename=filename)
 
 
-def build_cmd(target, version, skip_tests, filename='Dockerfile'):
+def build_cmd(target, version, skip_tests, no_cache, filename='Dockerfile'):
     config = load_shub_config()
     create_scrapinghub_yml_wizard(config, target=target, image=True)
     client = utils.get_docker_client()
@@ -67,7 +69,8 @@ def build_cmd(target, version, skip_tests, filename='Dockerfile'):
         path=project_dir,
         tag=image_name,
         decode=True,
-        dockerfile=filename
+        dockerfile=filename,
+        nocache=no_cache
     )
     build_progress = build_progress_cls(events)
     build_progress.show()

--- a/shub/image/upload.py
+++ b/shub/image/upload.py
@@ -34,18 +34,20 @@ Obviously it accepts all the options for the commands above.
 @click.option("--async", "async_", is_flag=True, help="[DEPRECATED] enable asynchronous mode",
               callback=utils.deprecate_async_parameter)
 @click.option("-S", "--skip-tests", help="skip testing image", is_flag=True)
+@click.option("-n", "--no-cache", is_flag=True,
+              help="Do not use cache when building the image")
 @click.option("-f", "--file", "filename", default='Dockerfile',
               help="Name of the Dockerfile (Default is 'PATH/Dockerfile')")
 def cli(target, debug, verbose, version, username, password, email,
-        apikey, insecure, async_, skip_tests, filename):
+        apikey, insecure, async_, skip_tests, no_cache, filename):
     upload_cmd(target, version, username, password, email, apikey, insecure,
-               async_, skip_tests, filename)
+               async_, skip_tests, no_cache, filename)
 
 
 def upload_cmd(target, version, username=None, password=None, email=None,
                apikey=None, insecure=False, async_=False, skip_tests=False,
-               filename='Dockerfile'):
-    build.build_cmd(target, version, skip_tests, filename=filename)
+               no_cache=False, filename='Dockerfile'):
+    build.build_cmd(target, version, skip_tests, no_cache, filename=filename)
     # skip tests for push command anyway because they run in build command if not skipped
     push.push_cmd(target, version, username, password, email, apikey,
                   insecure, skip_tests=True)

--- a/tests/image/test_build.py
+++ b/tests/image/test_build.py
@@ -29,7 +29,26 @@ def test_cli(docker_client_mock, project_dir, test_mock):
         decode=True,
         path=project_dir,
         tag='registry.io/user/project:1.0',
-        dockerfile='Dockerfile'
+        dockerfile='Dockerfile',
+        nocache=False
+    )
+    test_mock.assert_called_with("dev", None)
+
+
+def test_cli_with_nocache(docker_client_mock, project_dir, test_mock):
+    docker_client_mock.build.return_value = [
+        {"stream": "all is ok"},
+        {"stream": "Successfully built 12345"}
+    ]
+    runner = CliRunner()
+    result = runner.invoke(cli, ["dev", "-v", "--no-cache"])
+    assert result.exit_code == 0
+    docker_client_mock.build.assert_called_with(
+        decode=True,
+        path=project_dir,
+        tag='registry.io/user/project:1.0',
+        dockerfile='Dockerfile',
+        nocache=True
     )
     test_mock.assert_called_with("dev", None)
 
@@ -67,7 +86,8 @@ def test_cli_custom_version(docker_client_mock, project_dir, test_mock):
         decode=True,
         path=project_dir,
         tag='registry.io/user/project:test',
-        dockerfile='Dockerfile'
+        dockerfile='Dockerfile',
+        nocache=False
     )
     test_mock.assert_called_with("dev", "test")
 
@@ -106,7 +126,8 @@ def test_cli_skip_tests(docker_client_mock, test_mock, project_dir, skip_tests_f
         decode=True,
         path=project_dir,
         tag='registry.io/user/project:1.0',
-        dockerfile='Dockerfile'
+        dockerfile='Dockerfile',
+        nocache=False
     )
     assert test_mock.call_count == 0
 
@@ -124,7 +145,8 @@ def test_cli_custom_dockerfile(docker_client_mock, project_dir, test_mock, file_
         decode=True,
         path=project_dir,
         tag='registry.io/user/project:1.0',
-        dockerfile='Dockerfile'
+        dockerfile='Dockerfile',
+        nocache=False
     )
     test_mock.assert_called_with("dev", None)
 

--- a/tests/image/test_upload.py
+++ b/tests/image/test_upload.py
@@ -15,9 +15,9 @@ class TestUploadCli(TestCase):
             cli, ["dev", "-v", "--version", "test",
                   "--username", "user", "--password", "pass",
                   "--email", "mail", "--async", "--apikey", "apikey",
-                  "--skip-tests", "-f", "Dockerfile"])
+                  "--skip-tests", "--no-cache", "-f", "Dockerfile"])
         assert result.exit_code == 0
-        build.assert_called_with('dev', 'test', True, filename='Dockerfile')
+        build.assert_called_with('dev', 'test', True, True, filename='Dockerfile')
         push.assert_called_with(
             'dev', 'test', 'user', 'pass', 'mail', "apikey", False, skip_tests=True)
         deploy.assert_called_with(


### PR DESCRIPTION
enabled to use no-cache option when executing "shub image build" command.

# example

```
$ shub image build --no-cache
```

# details

All I implemented is to pass the no-cache option to the docker client.