### PR TITLE
Insecure exception with credential should raise warning

### DIFF
--- a/shub/image/utils.py
+++ b/shub/image/utils.py
@@ -14,7 +14,7 @@ from shub import config as shub_config
 from shub import utils as shub_utils
 from shub.exceptions import (
     ShubException, NotFoundException, BadConfigException, RemoteErrorException,
-    ShubDeprecationWarning, print_warning
+    ShubDeprecationWarning, print_warning, BadParameterException,
 )
 
 
@@ -157,16 +157,19 @@ def get_credentials(username=None, password=None, insecure=False,
     without 'account' query parameter which breaks login.
     """
     if insecure:
+        if username or password:
+            raise BadParameterException(
+                'Insecure credentials not compatible with username/password')
         return None, None
     elif apikey:
         return apikey, ' '
     elif username:
         if password is None:
-            raise click.BadParameter(
+            raise BadParameterException(
                 'Password is required when passing username.')
         return username, password
     elif password:
-        raise click.BadParameter(
+        raise BadParameterException(
             'Username is required when passing password.')
     return target_apikey, ' '
 

--- a/tests/image/test_utils.py
+++ b/tests/image/test_utils.py
@@ -6,7 +6,7 @@ from unittest import TestCase
 import mock
 import click
 import pytest
-from shub.exceptions import BadConfigException, NotFoundException
+from shub.exceptions import BadConfigException, BadParameterException, NotFoundException
 from shub.image.utils import (
     get_credentials,
     get_docker_client,
@@ -84,11 +84,17 @@ class ReleaseUtilsTest(TestCase):
 
     def test_get_credentials(self):
         assert get_credentials(insecure=True) == (None, None)
+        with pytest.raises(BadParameterException):
+            get_credentials(username='user', insecure=True)
+        with pytest.raises(BadParameterException):
+            get_credentials(password='pass', insecure=True)
         assert get_credentials(apikey='apikey') == ('apikey', ' ')
         assert get_credentials(
             username='user', password='pass') == ('user', 'pass')
-        with pytest.raises(click.BadParameter):
+        with pytest.raises(BadParameterException):
             get_credentials(username='user')
+        with pytest.raises(BadParameterException):
+            get_credentials(password='pass')
         assert get_credentials(target_apikey='tapikey') == ('tapikey', ' ')
 
     def test_get_image_registry(self):


### PR DESCRIPTION
If we are doing are getting the insecure credentials and we have username or password, an alert will raise.