### PR TITLE
KUMO-3333: Adding a new command to cancel multiple jobs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ ipaddress==1.0.17         # via docker-py
 pyyaml==5.1.1
 requests==2.22.0
 retrying==1.3.3
-scrapinghub==2.1.0
+scrapinghub==2.2.1
 six==1.10.0
 tqdm==4.11.2
 urllib3==1.25.3           # via requests

--- a/shub/cancel.py
+++ b/shub/cancel.py
@@ -1,0 +1,95 @@
+from __future__ import absolute_import
+
+import click
+
+from scrapinghub import ScrapinghubAPIError
+from scrapinghub.client.utils import parse_job_key
+
+from shub.utils import get_scrapinghub_client_from_config
+from shub.config import get_target_conf
+from shub.exceptions import (
+    ShubException,
+    BadParameterException,
+    SubcommandException,
+)
+
+
+HELP = """
+Cancel multiple jobs from Scrapy Cloud.
+
+The cancel command expects the project ID (target) followed by
+the pair containing the spider ID and Job ID:
+
+    shub cancel 12345 1/1 1/2 1/3
+
+If the project ID is not defined it is going to use the default
+project (as defined in scrapinghub.yml):
+
+    shub cancel 1/1 1/2 1/3
+
+The cancel command requires a confirmation that could be skipped
+with the flag --force/-f:
+
+    shub cancel --force 1/1 1/2 1/3
+"""
+
+
+SHORT_HELP = "Cancel multiple jobs from Scrapy Cloud"
+
+
+@click.command(help=HELP, short_help=SHORT_HELP)
+@click.argument("target_or_key")
+@click.argument("keys", nargs=-1)
+@click.option('--force', '-f', is_flag=True,
+              help='It ignores the confirmation prompt')
+def cli(target_or_key, keys, force):
+    # target_or_key contains a target or just another job key
+    if "/" in target_or_key:
+        keys = (target_or_key,) + keys
+        target = "default"
+    else:
+        target = target_or_key
+
+    targetconf = get_target_conf(target)
+    project_id = targetconf.project_id
+    client = get_scrapinghub_client_from_config(targetconf)
+    project = client.get_project(project_id)
+
+    try:
+        job_keys = [validate_job_key(project_id, key) for key in keys]
+    except (BadParameterException, SubcommandException) as err:
+        click.echo('Error during keys validation: %s' % str(err))
+        exit(1)
+
+    if not force:
+        jobs_str = ", ".join([str(job) for job in job_keys])
+        click.confirm(
+            'Do you want to cancel these %s jobs? \n\n%s \n\nconfirm?'
+            % (len(job_keys), jobs_str),
+            abort=True
+        )
+
+    try:
+        output = project.jobs.cancel(
+            keys=[str(job) for job in job_keys]
+        )
+    except (ValueError, ScrapinghubAPIError) as err:
+        raise ShubException(str(err))
+
+    click.echo(output)
+
+
+def validate_job_key(project_id, short_key):
+    job_key = "%s/%s" % (project_id, short_key)
+
+    if len(short_key.split("/")) != 2:
+        raise BadParameterException(
+            "keys must be defined as <spider_id>/<job_id>"
+        )
+
+    try:
+        return parse_job_key(job_key)
+    except ValueError as err:
+        raise BadParameterException(str(err))
+    except Exception as err:
+        raise SubcommandException(str(err))

--- a/shub/tool.py
+++ b/shub/tool.py
@@ -50,6 +50,7 @@ commands = [
     "copy_eggs",
     "migrate_eggs",
     "image",
+    "cancel",
 ]
 
 for command in commands:

--- a/shub/utils.py
+++ b/shub/utils.py
@@ -71,6 +71,12 @@ def remember_cwd():
         os.chdir(current_dir)
 
 
+def get_scrapinghub_client_from_config(conf):
+    return ScrapinghubClient(
+        conf.apikey, dash_endpoint=conf.endpoint
+    )
+
+
 def create_default_setup_py(**kwargs):
     closest = closest_file('scrapy.cfg')
     with remember_cwd():

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -1,0 +1,113 @@
+from __future__ import absolute_import
+
+import unittest
+import mock
+from collections import namedtuple
+
+from click.testing import CliRunner
+
+from shub import cancel
+from shub.exceptions import (
+    BadParameterException,
+    ShubException,
+)
+
+from .utils import AssertInvokeRaisesMixin, mock_conf
+
+
+class CancelTest(AssertInvokeRaisesMixin, unittest.TestCase):
+
+    def setUp(self):
+        self.runner = CliRunner()
+        self.conf = mock_conf(self)
+
+    @mock.patch('shub.cancel.get_scrapinghub_client_from_config')
+    def test_simple_cancel_call(self, mock_client):
+        client = mock_client.return_value
+        mock_proj = client.get_project.return_value
+        mock_proj.jobs.cancel.return_value = {'count': 2}
+
+        result = self.runner.invoke(
+            cancel.cli, ('123456', '1/1', '1/2',), input='y\n'
+        )
+
+        self.assertTrue("{'count': 2}" in result.output)
+        self.assertEqual(0, result.exit_code)
+        self.assertEqual(mock_proj.jobs.cancel.call_count, 1)
+        mock_proj.jobs.cancel.assert_called_with(
+            keys=['123456/1/1', '123456/1/2']
+        )
+
+    @mock.patch('shub.cancel.get_target_conf')
+    @mock.patch('shub.cancel.get_scrapinghub_client_from_config')
+    def test_cancel_default_project(self, mock_client, targetconf):
+        client = mock_client.return_value
+        mock_proj = client.get_project.return_value
+        mock_proj.jobs.cancel.return_value = {'count': 2}
+
+        Target = namedtuple('Target', 'project_id')
+        targetconf.return_value = Target(project_id='123456')
+
+        result = self.runner.invoke(
+            cancel.cli, ('1/1', '1/2',), input='y\n'
+        )
+
+        self.assertTrue("{'count': 2}" in result.output)
+        self.assertEqual(0, result.exit_code)
+        self.assertEqual(mock_proj.jobs.cancel.call_count, 1)
+        mock_proj.jobs.cancel.assert_called_with(
+            keys=['123456/1/1', '123456/1/2']
+        )
+
+    @mock.patch('shub.cancel.get_scrapinghub_client_from_config')
+    def test_invalid_job_key(self, mock_client):
+        self.assertInvokeRaises(
+            SystemExit,
+            cancel.cli,
+            ('123456', '1/1', '1',),
+            input='y\n'
+        )
+
+        self.assertInvokeRaises(
+            SystemExit,
+            cancel.cli,
+            ('123456', '1/abc', '1',),
+            input='y\n'
+        )
+
+    @mock.patch('shub.cancel.get_scrapinghub_client_from_config')
+    def test_cancel_failure(self, mock_client):
+        client = mock_client.return_value
+        mock_proj = client.get_project.return_value
+        mock_proj.jobs.cancel.side_effect = ValueError('Error msg')
+
+        self.assertInvokeRaises(
+            ShubException,
+            cancel.cli,
+            ('123456', '1/1', '1/2',),
+            input='y\n',
+        )
+
+    @mock.patch('shub.cancel.get_scrapinghub_client_from_config')
+    def test_cancel_abort(self, mock_client):
+        client = mock_client.return_value
+        client.get_project.return_value
+
+        result = self.runner.invoke(
+            cancel.cli, ('123456', '1/1', '1/2',), input='N\n',
+        )
+        self.assertTrue('Aborted!' in result.output)
+
+    def test_validate_job_key(self):
+        with self.assertRaises(BadParameterException):
+            cancel.validate_job_key('123456', '1')
+
+        with self.assertRaises(BadParameterException):
+            cancel.validate_job_key('123456', '1/abc')
+
+        with self.assertRaises(BadParameterException):
+            cancel.validate_job_key('123456', '')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR adds a new command called `cancel`, which aims to stop running and awaiting jobs. 
It uses the new `python-scrapinghub`'s `cancel` method.

Usage examples:
  $ shub cancel <project_id> <spider_id>/<job_id> <spider_id>/<job_id> ...
  $ shub cancel <spider_id>/<job_id> <spider_id>/<job_id> ...
  $ shub cancel --force <spider_id>/<job_id> <spider_id>/<job_id> ...
