### PR TITLE
Use rstrip to drop extra newline (closes #361)

### DIFF
--- a/shub/image/build.py
+++ b/shub/image/build.py
@@ -91,7 +91,7 @@ class _LoggedBuildProgress(utils.BaseProgress):
             self.handle_stream_event(event)
 
     def handle_stream_event(self, event):
-        utils.debug_log("{}".format(event['stream'][:-1]))
+        utils.debug_log("{}".format(event['stream'].rstrip()))
 
 
 class _BuildProgress(_LoggedBuildProgress):


### PR DESCRIPTION
The logic should drop extra new lines only, not any last character.