### PR TITLE
Image push: provide explicit option to re-auth

### DIFF
--- a/shub/image/push.py
+++ b/shub/image/push.py
@@ -43,9 +43,8 @@ otherwise you have to enter your credentials (at least username/password).
               help="re-authenticate to registry")
 def cli(target, debug, verbose, version, username, password, email, apikey,
         insecure, skip_tests, reauth):
-    push_cmd(
-        target, version, username, password, email, apikey, insecure,
-        skip_tests, reauth)
+    push_cmd(target, version, username, password, email, apikey, insecure,
+             skip_tests, reauth)
 
 
 def push_cmd(target, version, username, password, email, apikey, insecure,

--- a/shub/image/upload.py
+++ b/shub/image/upload.py
@@ -34,22 +34,24 @@ Obviously it accepts all the options for the commands above.
 @click.option("--async", "async_", is_flag=True, help="[DEPRECATED] enable asynchronous mode",
               callback=utils.deprecate_async_parameter)
 @click.option("-S", "--skip-tests", help="skip testing image", is_flag=True)
+@click.option("-R", "--reauth", is_flag=True,
+              help="re-authenticate to registry before pushing")
 @click.option("-n", "--no-cache", is_flag=True,
               help="Do not use cache when building the image")
 @click.option("-f", "--file", "filename", default='Dockerfile',
               help="Name of the Dockerfile (Default is 'PATH/Dockerfile')")
 def cli(target, debug, verbose, version, username, password, email,
-        apikey, insecure, async_, skip_tests, no_cache, filename):
+        apikey, insecure, async_, skip_tests, reauth, no_cache, filename):
     upload_cmd(target, version, username, password, email, apikey, insecure,
-               async_, skip_tests, no_cache, filename)
+               async_, skip_tests, reauth, no_cache, filename)
 
 
 def upload_cmd(target, version, username=None, password=None, email=None,
                apikey=None, insecure=False, async_=False, skip_tests=False,
-               no_cache=False, filename='Dockerfile'):
+               reauth=False, no_cache=False, filename='Dockerfile'):
     build.build_cmd(target, version, skip_tests, no_cache, filename=filename)
     # skip tests for push command anyway because they run in build command if not skipped
     push.push_cmd(target, version, username, password, email, apikey,
-                  insecure, skip_tests=True)
+                  insecure, skip_tests=True, reauth=reauth)
     deploy.deploy_cmd(target, version, username, password, email,
                       apikey, insecure, async_)

--- a/tests/image/test_push.py
+++ b/tests/image/test_push.py
@@ -192,6 +192,19 @@ def test_cli_login_fail(docker_client_mock, test_mock):
 
 
 @pytest.mark.usefixtures('project_dir')
+def test_cli_login_fail_auth(docker_client_mock, test_mock):
+    docker_client_mock.login.return_value = {
+        'error': 'unsupported: Please authorize with docker login.'}
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["dev", "--version", "test", "--username", "user",
+              "--password", "pass", "--email", "mail"])
+    assert result.exit_code == shub_exceptions.RemoteErrorException.exit_code
+    assert 'Docker registry login error' in result.stdout
+    test_mock.assert_called_with("dev", "test")
+
+
+@pytest.mark.usefixtures('project_dir')
 def test_cli_push_fail(docker_client_mock, test_mock):
     docker_client_mock.login.return_value = {"Status": "Login Succeeded"}
     docker_client_mock.push.return_value = [{"error": "Failed:(", "errorDetail": ""}]

--- a/tests/image/test_push.py
+++ b/tests/image/test_push.py
@@ -200,7 +200,7 @@ def test_cli_login_fail_auth(docker_client_mock, test_mock):
         cli, ["dev", "--version", "test", "--username", "user",
               "--password", "pass", "--email", "mail"])
     assert result.exit_code == shub_exceptions.RemoteErrorException.exit_code
-    assert 'Docker registry login error' in result.stdout
+    assert 'Docker registry login error' in result.output
     test_mock.assert_called_with("dev", "test")
 
 

--- a/tests/image/test_upload.py
+++ b/tests/image/test_upload.py
@@ -15,10 +15,11 @@ class TestUploadCli(TestCase):
             cli, ["dev", "-v", "--version", "test",
                   "--username", "user", "--password", "pass",
                   "--email", "mail", "--async", "--apikey", "apikey",
-                  "--skip-tests", "--no-cache", "-f", "Dockerfile"])
+                  "--skip-tests", "--no-cache", "-f", "Dockerfile", "--reauth"])
         assert result.exit_code == 0
         build.assert_called_with('dev', 'test', True, True, filename='Dockerfile')
         push.assert_called_with(
-            'dev', 'test', 'user', 'pass', 'mail', "apikey", False, skip_tests=True)
+            'dev', 'test', 'user', 'pass', 'mail', "apikey", False, reauth=True,
+            skip_tests=True)
         deploy.assert_called_with(
             'dev', 'test', 'user', 'pass', 'mail', "apikey", False, True)


### PR DESCRIPTION
After docker-login step is completed once, it adds a record to its local config with all key data about login, and doesn't try to re-authenticate unless the data is gone. However, we noticed a few cases when explicit re-authentication is required. The PR adds an option to enforce the re-authentication process if needed.