### PR TITLE
Cleanup intermediate build containers 

### DIFF
--- a/shub/image/build.py
+++ b/shub/image/build.py
@@ -70,7 +70,8 @@ def build_cmd(target, version, skip_tests, no_cache, filename='Dockerfile'):
         tag=image_name,
         decode=True,
         dockerfile=filename,
-        nocache=no_cache
+        nocache=no_cache,
+        rm=True,
     )
     build_progress = build_progress_cls(events)
     build_progress.show()

--- a/tests/image/test_build.py
+++ b/tests/image/test_build.py
@@ -30,7 +30,8 @@ def test_cli(docker_client_mock, project_dir, test_mock):
         path=project_dir,
         tag='registry.io/user/project:1.0',
         dockerfile='Dockerfile',
-        nocache=False
+        nocache=False,
+        rm=True
     )
     test_mock.assert_called_with("dev", None)
 
@@ -48,7 +49,8 @@ def test_cli_with_nocache(docker_client_mock, project_dir, test_mock):
         path=project_dir,
         tag='registry.io/user/project:1.0',
         dockerfile='Dockerfile',
-        nocache=True
+        nocache=True,
+        rm=True
     )
     test_mock.assert_called_with("dev", None)
 
@@ -87,7 +89,8 @@ def test_cli_custom_version(docker_client_mock, project_dir, test_mock):
         path=project_dir,
         tag='registry.io/user/project:test',
         dockerfile='Dockerfile',
-        nocache=False
+        nocache=False,
+        rm=True
     )
     test_mock.assert_called_with("dev", "test")
 
@@ -127,7 +130,8 @@ def test_cli_skip_tests(docker_client_mock, test_mock, project_dir, skip_tests_f
         path=project_dir,
         tag='registry.io/user/project:1.0',
         dockerfile='Dockerfile',
-        nocache=False
+        nocache=False,
+        rm=True
     )
     assert test_mock.call_count == 0
 
@@ -146,7 +150,8 @@ def test_cli_custom_dockerfile(docker_client_mock, project_dir, test_mock, file_
         path=project_dir,
         tag='registry.io/user/project:1.0',
         dockerfile='Dockerfile',
-        nocache=False
+        nocache=False,
+        rm=True
     )
     test_mock.assert_called_with("dev", None)
 


### PR DESCRIPTION
This change makes `shub image build` behave like `docker build --rm=true .` which has become the default in docker command but was preserved in the client for backward compatibility. I don't know if anyone relies on this behavior so maybe it doesn't make sense but if it does I suppose it's better to shelve this till next major release.