### PR TITLE
allow to pass build arguments to docker client

### DIFF
--- a/shub/image/upload.py
+++ b/shub/image/upload.py
@@ -38,18 +38,20 @@ Obviously it accepts all the options for the commands above.
               help="re-authenticate to registry before pushing")
 @click.option("-n", "--no-cache", is_flag=True,
               help="Do not use cache when building the image")
+@click.option("-b", "--build-arg", multiple=True,
+              help="Allow to pass build arguments to docker client.")
 @click.option("-f", "--file", "filename", default='Dockerfile',
               help="Name of the Dockerfile (Default is 'PATH/Dockerfile')")
 def cli(target, debug, verbose, version, username, password, email,
-        apikey, insecure, async_, skip_tests, reauth, no_cache, filename):
+        apikey, insecure, async_, skip_tests, reauth, no_cache, build_arg, filename):
     upload_cmd(target, version, username, password, email, apikey, insecure,
-               async_, skip_tests, reauth, no_cache, filename)
+               async_, skip_tests, reauth, no_cache, build_arg, filename)
 
 
 def upload_cmd(target, version, username=None, password=None, email=None,
                apikey=None, insecure=False, async_=False, skip_tests=False,
-               reauth=False, no_cache=False, filename='Dockerfile'):
-    build.build_cmd(target, version, skip_tests, no_cache, filename=filename)
+               reauth=False, no_cache=False, build_arg=(), filename='Dockerfile'):
+    build.build_cmd(target, version, skip_tests, no_cache, build_arg, filename=filename)
     # skip tests for push command anyway because they run in build command if not skipped
     push.push_cmd(target, version, username, password, email, apikey,
                   insecure, skip_tests=True, reauth=reauth)

--- a/tests/image/test_build.py
+++ b/tests/image/test_build.py
@@ -31,7 +31,8 @@ def test_cli(docker_client_mock, project_dir, test_mock):
         tag='registry.io/user/project:1.0',
         dockerfile='Dockerfile',
         nocache=False,
-        rm=True
+        rm=True,
+        buildargs={}
     )
     test_mock.assert_called_with("dev", None)
 
@@ -50,7 +51,29 @@ def test_cli_with_nocache(docker_client_mock, project_dir, test_mock):
         tag='registry.io/user/project:1.0',
         dockerfile='Dockerfile',
         nocache=True,
-        rm=True
+        rm=True,
+        buildargs={}
+    )
+    test_mock.assert_called_with("dev", None)
+
+
+def test_cli_with_buildargs(docker_client_mock, project_dir, test_mock):
+    docker_client_mock.build.return_value = [
+        {"stream": "all is ok"},
+        {"stream": "Successfully built 12345"}
+    ]
+    runner = CliRunner()
+    result = runner.invoke(cli, ["dev", "-v", "-b", "AWS_KEY=asdasdeg", "-b",
+                                 "AWS_SEC=ashthku", "-b", "PARAM=query=4"])
+    assert result.exit_code == 0
+    docker_client_mock.build.assert_called_with(
+        decode=True,
+        path=project_dir,
+        tag='registry.io/user/project:1.0',
+        dockerfile='Dockerfile',
+        nocache=False,
+        rm=True,
+        buildargs={'AWS_KEY': 'asdasdeg', 'AWS_SEC': 'ashthku', 'PARAM': 'query=4'}
     )
     test_mock.assert_called_with("dev", None)
 
@@ -90,7 +113,8 @@ def test_cli_custom_version(docker_client_mock, project_dir, test_mock):
         tag='registry.io/user/project:test',
         dockerfile='Dockerfile',
         nocache=False,
-        rm=True
+        rm=True,
+        buildargs={}
     )
     test_mock.assert_called_with("dev", "test")
 
@@ -131,7 +155,8 @@ def test_cli_skip_tests(docker_client_mock, test_mock, project_dir, skip_tests_f
         tag='registry.io/user/project:1.0',
         dockerfile='Dockerfile',
         nocache=False,
-        rm=True
+        rm=True,
+        buildargs={}
     )
     assert test_mock.call_count == 0
 
@@ -151,7 +176,8 @@ def test_cli_custom_dockerfile(docker_client_mock, project_dir, test_mock, file_
         tag='registry.io/user/project:1.0',
         dockerfile='Dockerfile',
         nocache=False,
-        rm=True
+        rm=True,
+        buildargs={}
     )
     test_mock.assert_called_with("dev", None)
 

--- a/tests/image/test_upload.py
+++ b/tests/image/test_upload.py
@@ -17,7 +17,7 @@ class TestUploadCli(TestCase):
                   "--email", "mail", "--async", "--apikey", "apikey",
                   "--skip-tests", "--no-cache", "-f", "Dockerfile", "--reauth"])
         assert result.exit_code == 0
-        build.assert_called_with('dev', 'test', True, True, filename='Dockerfile')
+        build.assert_called_with('dev', 'test', True, True, (), filename='Dockerfile')
         push.assert_called_with(
             'dev', 'test', 'user', 'pass', 'mail', "apikey", False, reauth=True,
             skip_tests=True)


### PR DESCRIPTION
Needed for passing things like private credentials without hard coding them in Dockerfile.