### PR TITLE
Upgrade tqdm

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ six
 toml
 
 click==7.0
-tqdm==4.11.2
+tqdm
 scrapinghub>=2.3.1
 
 # address known vulnerabilities


### PR DESCRIPTION
tqdm 4.11.2 is incompatible with python 3.9 due to sys.setcheckinterval being removed, see #389