### PR TITLE
Stop using Python 3.5 for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python: 3.6
 sudo: false
 env:
   - TOX_ENV=py27
-  - TOX_ENV=py35
+  - TOX_ENV=py36
   - TOX_ENV=freeze
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-python: 3.5
+python: 3.6
 sudo: false
 env:
   - TOX_ENV=py27
@@ -25,11 +25,6 @@ matrix:
     - os: osx
       language: generic
       env:
-        - TOX_ENV=py35
-        - PYTHON_VERSION='3.5.8'
-    - os: osx
-      language: generic
-      env:
         - TOX_ENV=py36
         - PYTHON_VERSION='3.6.9'
     - os: osx
@@ -51,7 +46,7 @@ matrix:
       language: generic
       env:
         - TOX_ENV=freeze
-        - PYTHON_VERSION='3.5.8'
+        - PYTHON_VERSION='3.6.9'
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,6 @@ environment:
   matrix:
     - PYTHON: "C:\\Python27"
       TOX_ENV: py27
-    - PYTHON: "C:\\Python35"
-      TOX_ENV: py35
     - PYTHON: "C:\\Python36"
       TOX_ENV: py36
     - PYTHON: "C:\\Python37"
@@ -17,7 +15,7 @@ environment:
     - PYTHON: "C:\\Python39"
       TOX_ENV: py39
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-    - PYTHON: "C:\\Python35"
+    - PYTHON: "C:\\Python36"
       TOX_ENV: freeze
 
 branches:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,8 +44,9 @@ after_test:
   - if "%TOX_ENV%" == "freeze" (7z a %APPVEYOR_BUILD_FOLDER%\dist_bin\shub-%APPVEYOR_REPO_TAG_NAME%-windows-%PLATFORM%.zip %APPVEYOR_BUILD_FOLDER%\dist_bin\shub.exe) else (echo "Not in freeze environment, skipping zip creation")
 
 deploy:
-  release: v$(appveyor_build_version)
-  description: 'shub v$(appveyor_build_version)'
+  tag: $(APPVEYOR_REPO_TAG_NAME)
+  release: $(APPVEYOR_REPO_TAG_NAME)
+  description: 'shub $(APPVEYOR_REPO_TAG_NAME)'
   provider: GitHub
   auth_token:
     secure: dYqilqswNHo/A+08lISafEpFx/wNOzk/7Iz4aTHode5BbVcGrLXWkNFczw6zzIN8

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36,py37,py38,py39
+envlist = py27,py36,py37,py38,py39
 
 [testenv]
 setenv =


### PR DESCRIPTION
Python 3.5 reached its EOL in September 2020, we had to drop the support for it a long time ago.