### PR TITLE
Fix deps conversion

### DIFF
--- a/shub/deploy.py
+++ b/shub/deploy.py
@@ -11,11 +11,11 @@ import click
 # Not used in code but needed in runtime, don't remove!
 import setuptools
 import setuptools.msvc  # noqa
+
 import toml
 from six.moves.urllib.parse import urljoin
 
-from shub.config import (SH_IMAGES_REGISTRY, list_targets_callback,
-                         load_shub_config)
+from shub.config import (SH_IMAGES_REGISTRY, list_targets_callback, load_shub_config)
 from shub.exceptions import (BadParameterException, NotFoundException,
                              ShubException)
 from shub.image.upload import upload_cmd
@@ -170,8 +170,7 @@ def _get_pipfile_requirements(tmpdir=None):
         from pipenv.utils.indexes import prepare_pip_source_args
     except ImportError:
         try:
-            from pipenv.utils import (convert_deps_to_pip,
-                                      prepare_pip_source_args)
+            from pipenv.utils import (convert_deps_to_pip, prepare_pip_source_args)
         except ImportError:
             raise ImportError('You need pipenv installed to deploy with Pipfile')
     try:

--- a/shub/deploy.py
+++ b/shub/deploy.py
@@ -196,7 +196,7 @@ def _get_pipfile_requirements(tmpdir=None):
 def _add_sources(_reqs_file, _sources, tmpdir=None):
     tmp = tempfile.NamedTemporaryFile(delete=False, suffix="-requirements.txt", dir=tmpdir)
     tmp.write(_sources + b'\n')
-    # Keep backward compatibility with pipenv<=2022.4.8
+    # Keep backward compatibility with pipenv<=2022.8.30
     try:
         with open(_reqs_file, 'rb') as f:
             tmp.write(f.read())

--- a/shub/deploy.py
+++ b/shub/deploy.py
@@ -7,17 +7,16 @@ import shutil
 import tempfile
 from typing import AnyStr, Optional, Union
 
-import click
 # Not used in code but needed in runtime, don't remove!
 import setuptools
 import setuptools.msvc  # noqa
 
+import click
 import toml
 from six.moves.urllib.parse import urljoin
 
-from shub.config import (SH_IMAGES_REGISTRY, list_targets_callback, load_shub_config)
-from shub.exceptions import (BadParameterException, NotFoundException,
-                             ShubException)
+from shub.config import SH_IMAGES_REGISTRY, list_targets_callback, load_shub_config
+from shub.exceptions import BadParameterException, NotFoundException,ShubException
 from shub.image.upload import upload_cmd
 from shub.utils import (create_default_setup_py, create_scrapinghub_yml_wizard,
                         inside_project, make_deploy_request, run_python)
@@ -170,7 +169,7 @@ def _get_pipfile_requirements(tmpdir=None):
         from pipenv.utils.indexes import prepare_pip_source_args
     except ImportError:
         try:
-            from pipenv.utils import (convert_deps_to_pip, prepare_pip_source_args)
+            from pipenv.utils import convert_deps_to_pip, prepare_pip_source_args
         except ImportError:
             raise ImportError('You need pipenv installed to deploy with Pipfile')
     try:

--- a/shub/deploy.py
+++ b/shub/deploy.py
@@ -1,25 +1,26 @@
 from __future__ import absolute_import
-import os
+
 import glob
+import json
+import os
 import shutil
 import tempfile
-import json
-from six.moves.urllib.parse import urljoin
+from typing import AnyStr, Optional, Union
 
 import click
-import toml
 # Not used in code but needed in runtime, don't remove!
 import setuptools
 import setuptools.msvc  # noqa
+import toml
+from six.moves.urllib.parse import urljoin
 
-from shub.config import (list_targets_callback, load_shub_config,
-                         SH_IMAGES_REGISTRY)
+from shub.config import (SH_IMAGES_REGISTRY, list_targets_callback,
+                         load_shub_config)
 from shub.exceptions import (BadParameterException, NotFoundException,
                              ShubException)
+from shub.image.upload import upload_cmd
 from shub.utils import (create_default_setup_py, create_scrapinghub_yml_wizard,
                         inside_project, make_deploy_request, run_python)
-from shub.image.upload import upload_cmd
-
 
 HELP = """
 Deploy the current folder's Scrapy project to Scrapy Cloud.
@@ -169,7 +170,8 @@ def _get_pipfile_requirements(tmpdir=None):
         from pipenv.utils.indexes import prepare_pip_source_args
     except ImportError:
         try:
-            from pipenv.utils import convert_deps_to_pip, prepare_pip_source_args
+            from pipenv.utils import (convert_deps_to_pip,
+                                      prepare_pip_source_args)
         except ImportError:
             raise ImportError('You need pipenv installed to deploy with Pipfile')
     try:
@@ -193,15 +195,15 @@ def _get_pipfile_requirements(tmpdir=None):
     return open(_add_sources(convert_deps_to_pip(deps), _sources=sources.encode(), tmpdir=tmpdir), 'rb')
 
 
-def _add_sources(_reqs_file, _sources, tmpdir=None):
+def _add_sources(_requirements: Union[str, list], _sources: bytes, tmpdir: Optional[AnyStr] = None) -> str:
     tmp = tempfile.NamedTemporaryFile(delete=False, suffix="-requirements.txt", dir=tmpdir)
     tmp.write(_sources + b'\n')
     # Keep backward compatibility with pipenv<=2022.8.30
-    try:
-        with open(_reqs_file, 'rb') as f:
+    if isinstance(_requirements, list):
+        tmp.write('\n'.join(_requirements).encode('utf-8'))
+    else:
+        with open(_requirements, 'rb') as f:
             tmp.write(f.read())
-    except TypeError:
-        tmp.write('\n'.join(_reqs_file).encode('utf-8'))
     tmp.flush()
     tmp.close()
     return tmp.name

--- a/shub/deploy.py
+++ b/shub/deploy.py
@@ -196,8 +196,12 @@ def _get_pipfile_requirements(tmpdir=None):
 def _add_sources(_reqs_file, _sources, tmpdir=None):
     tmp = tempfile.NamedTemporaryFile(delete=False, suffix="-requirements.txt", dir=tmpdir)
     tmp.write(_sources + b'\n')
-    with open(_reqs_file, 'rb') as f:
-        tmp.write(f.read())
+    # Keep backward compatibility with pipenv<=2022.4.8
+    try:
+        with open(_reqs_file, 'rb') as f:
+            tmp.write(f.read())
+    except TypeError:
+        tmp.write('\n'.join(_reqs_file).encode('utf-8'))
     tmp.flush()
     tmp.close()
     return tmp.name

--- a/shub/deploy.py
+++ b/shub/deploy.py
@@ -16,7 +16,7 @@ import toml
 from six.moves.urllib.parse import urljoin
 
 from shub.config import SH_IMAGES_REGISTRY, list_targets_callback, load_shub_config
-from shub.exceptions import BadParameterException, NotFoundException,ShubException
+from shub.exceptions import BadParameterException, NotFoundException, ShubException
 from shub.image.upload import upload_cmd
 from shub.utils import (create_default_setup_py, create_scrapinghub_yml_wizard,
                         inside_project, make_deploy_request, run_python)

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -257,16 +257,18 @@ class DeployFilesTest(unittest.TestCase):
         self.assertIn('main content', files_main['eggs'])
 
     def test_add_sources(self):
-        convert_deps_to_pip = Mock(side_effect=[
-            './requirements.txt',
-            ['package==0.0.0', 'hash-package==0.0.1', 'hash-package2==0.0.1']
-        ])
-        _sources = (b'-i https://pypi.python.org/simple '
-                    b'--extra-index-url https://example.external-index.org/simple')
-        self.assertIsInstance(deploy._add_sources(convert_deps_to_pip(),
-                                                  _sources), str)
-        self.assertIsInstance(deploy._add_sources(convert_deps_to_pip(),
-                                                  _sources), str)
+        convert_deps_to_pip = Mock(
+            side_effect=[
+                './requirements.txt',
+                ['package==0.0.0', 'hash-package==0.0.1', 'hash-package2==0.0.1'],
+            ],
+        )
+        _sources = (
+            b'-i https://pypi.python.org/simple'
+            b'--extra-index-url https://example.external-index.org/simple',
+        )
+        self.assertIsInstance(deploy._add_sources(convert_deps_to_pip(), _sources), str)
+        self.assertIsInstance(deploy._add_sources(convert_deps_to_pip(), _sources), str)
 
     def pipfile_test(self, req_name):
         with self.runner.isolated_filesystem():

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 
 import os
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 import requests
 from click.testing import CliRunner
@@ -255,6 +255,18 @@ class DeployFilesTest(unittest.TestCase):
         # but do upload the main egg if it's directly requested
         self.assertEqual(len(files_main['eggs']), 4)
         self.assertIn('main content', files_main['eggs'])
+
+    def test_add_sources(self):
+        convert_deps_to_pip = Mock(side_effect=[
+            './requirements.txt',
+            ['package==0.0.0', 'hash-package==0.0.1', 'hash-package2==0.0.1']
+        ])
+        _sources = (b'-i https://pypi.python.org/simple '
+                    b'--extra-index-url https://example.external-index.org/simple')
+        self.assertIsInstance(deploy._add_sources(convert_deps_to_pip(),
+                                                  _sources), str)
+        self.assertIsInstance(deploy._add_sources(convert_deps_to_pip(),
+                                                  _sources), str)
 
     def pipfile_test(self, req_name):
         with self.runner.isolated_filesystem():

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -264,8 +264,8 @@ class DeployFilesTest(unittest.TestCase):
             ],
         )
         _sources = (
-            b'-i https://pypi.python.org/simple'
-            b'--extra-index-url https://example.external-index.org/simple',
+            b'-i https://pypi.python.org/simple '
+            b'--extra-index-url https://example.external-index.org/simple'
         )
         self.assertIsInstance(deploy._add_sources(convert_deps_to_pip(), _sources), str)
         self.assertIsInstance(deploy._add_sources(convert_deps_to_pip(), _sources), str)


### PR DESCRIPTION
Since Pipenv v2022.8.30 the function `convert_deps_to_pip` returns a list of strings containing all the dependencies found in the Pipfile converted to Pip format. So, I added a try/exception statement to catch the `TypeError` exception, when the previous code tries to open the temporary file, and write the dependencies to the requirements file.