### PR TITLE
Fix option name (ignore-size -> ignore_size)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,22 +11,28 @@ on:
 jobs:
   tests-ubuntu:
     name: "Test: py${{ matrix.python-version }}, Ubuntu"
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
         - python-version: '3.6'
+          os: ubuntu-20.04
           tox-env: min
         - python-version: '3.6'
+          os: ubuntu-20.04
           tox-env: py
         - python-version: '3.7'
+          os: ubuntu-latest
           tox-env: py
         - python-version: '3.8'
+          os: ubuntu-latest
           tox-env: py
         - python-version: '3.9'
+          os: ubuntu-latest
           tox-env: py
         - python-version: '3.10'
+          os: ubuntu-latest
           tox-env: py
 
     steps:

--- a/shub/utils.py
+++ b/shub/utils.py
@@ -130,7 +130,7 @@ def make_deploy_request(url, data, files, auth, verbose, keep_log):
 def _check_deploy_files_size(files):
     """Ensure that request's files total size is less than current limit."""
     ctx = click.get_current_context(silent=True)
-    if not isinstance(files, list) or ctx and ctx.params.get('ignore-size'):
+    if not isinstance(files, list) or ctx and ctx.params.get('ignore_size'):
         return
     files_size = sum(
         len(fp) if isinstance(fp, string_types)


### PR DESCRIPTION
Quick fix (no tests :smiling_face_with_tear:) after internal report from developers.

With the following patch (after line https://github.com/scrapinghub/shub/blob/v2.14.3/shub/utils.py#L132)
```diff
diff --git a/shub/utils.py b/shub/utils.py
index 11665ec..c32ba67 100644
--- a/shub/utils.py
+++ b/shub/utils.py
@@ -130,6 +130,8 @@ def make_deploy_request(url, data, files, auth, verbose, keep_log):
 def _check_deploy_files_size(files):
     """Ensure that request's files total size is less than current limit."""
     ctx = click.get_current_context(silent=True)
+    import pdb
+    pdb.set_trace()
     if not isinstance(files, list) or ctx and ctx.params.get('ignore-size'):
         return
     files_size = sum(
```

we can see the option name:
```
$ shub deploy --ignore-size
Packing version 40136e4-main
Deploying to Scrapy Cloud project "445393"
> /home/eugenio/zyte/scheduler-load-test/venv-scheduler-load-test/lib/python3.9/site-packages/shub/utils.py(135)_check_deploy_files_size()
-> if not isinstance(files, list) or ctx and ctx.params.get('ignore_size'):
(Pdb) ctx.params
{'ignore_size': True, 'target': 'default', 'version': None, 'debug': False, 'egg': None, 'build_egg': None, 'verbose': False, 'keep_log': False}
(Pdb) 

```