### PR TITLE
[Documentation] `shub Image upload` documentation correction.

### DIFF
--- a/docs/deploy-custom-image.rst
+++ b/docs/deploy-custom-image.rst
@@ -375,14 +375,16 @@ It is a shortcut for the build -> push -> deploy chain of commands.
 
 ::
 
-    $ shub image upload --version 1.0.4 \
-    --username johndoe --password johndoepwd private
+    $ shub image upload private --version 1.0.4 \
+    --username johndoe --password johndoepwd
 
 
 Options for upload
 ^^^^^^^^^^^^^^^^^^
 
-The ``upload`` command accepts the same parameters as the :ref:`deploy <commands-deploy>` command except `--target` which can be passed as an argument.
+The ``upload`` command accepts the same parameters as the :ref:`deploy
+<commands-deploy>` command, except for ``--target``, which can be passed as an
+argument.
 
 
 .. _commands-check:

--- a/docs/deploy-custom-image.rst
+++ b/docs/deploy-custom-image.rst
@@ -375,14 +375,14 @@ It is a shortcut for the build -> push -> deploy chain of commands.
 
 ::
 
-    $ shub image upload --target private --version 1.0.4 \
-    --username johndoe --password johndoepwd
+    $ shub image upload --version 1.0.4 \
+    --username johndoe --password johndoepwd private
 
 
 Options for upload
 ^^^^^^^^^^^^^^^^^^
 
-The ``upload`` command accepts the same parameters as the :ref:`deploy <commands-deploy>` command.
+The ``upload`` command accepts the same parameters as the :ref:`deploy <commands-deploy>` command except `--target` which can be passed as an argument.
 
 
 .. _commands-check:


### PR DESCRIPTION
- upload command does not support `--target` parameter and returns error.
- As per code target can be specified as an argument.
- Updated example and  and options