### PR TITLE
Fix VCS pip line entry in test suite

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/freeze-release-publish.yml
+++ b/.github/workflows/freeze-release-publish.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
 

--- a/.github/workflows/freeze-release-publish.yml
+++ b/.github/workflows/freeze-release-publish.yml
@@ -42,7 +42,7 @@ jobs:
       run: tar -czvf shub-${{ runner.os }}.tar.gz dist_bin/shub
 
     - name: Upload binary
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: shub-${{ runner.os }}
         path: |

--- a/.github/workflows/freeze-release-publish.yml
+++ b/.github/workflows/freeze-release-publish.yml
@@ -77,7 +77,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -97,7 +97,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -135,7 +135,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,16 +78,16 @@ jobs:
         include:
         - python-version: '3.6'
           tox-env: min
-          os: macos-latest-large
+          os: macos-13
         - python-version: '3.6'
           tox-env: py
-          os: macos-latest-large
+          os: macos-13
         - python-version: '3.7'
           tox-env: py
-          os: macos-latest-large
+          os: macos-13
         - python-version: '3.8'
           tox-env: py
-          os: macos-latest-large
+          os: macos-13
         - python-version: '3.9'
           tox-env: py
         - python-version: '3.10'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
           os: ubuntu-20.04
           tox-env: py
         - python-version: '3.7'
-          os: ubuntu-latest
+          os: ubuntu-22.04
           tox-env: py
         - python-version: '3.8'
           os: ubuntu-latest
@@ -71,19 +71,23 @@ jobs:
 
   tests-macos:
     name: "Test: py${{ matrix.python-version }}, macOS"
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os || 'macos-latest' }}
     strategy:
       fail-fast: false
       matrix:
         include:
         - python-version: '3.6'
           tox-env: min
+          os: macos-latest-large
         - python-version: '3.6'
           tox-env: py
+          os: macos-latest-large
         - python-version: '3.7'
           tox-env: py
+          os: macos-latest-large
         - python-version: '3.8'
           tox-env: py
+          os: macos-latest-large
         - python-version: '3.9'
           tox-env: py
         - python-version: '3.10'

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -3,6 +3,8 @@ import sys
 import unittest
 from unittest.mock import patch, Mock
 
+from packaging.version import parse
+from pipenv import __version__ as pipenv_version
 import requests
 from click.testing import CliRunner
 
@@ -320,7 +322,11 @@ class DeployFilesTest(unittest.TestCase):
             'hash-package2==0.0.1',
             'git+https://github.com/vcs/package.git@master#egg=vcs-package'
             if sys.version_info < (3, 8)
-            else 'vcs-package@ git+https://github.com/vcs/package.git@master'
+            else (
+                'vcs-package@ git+https://github.com/vcs/package.git@master'
+                if parse(pipenv_version) < parse("2024.3.0")
+                else 'vcs-package @ git+https://github.com/vcs/package.git@master'
+            )
         })
 
     def test_pipfile_names(self):

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ commands =
 [testenv:min]
 deps =
     {[testenv]deps}
+    pipenv<2024.3.0
 
 [testenv:freeze]
 install_command =


### PR DESCRIPTION
Since pipenv version 2024.3.0, an additional whitespace character is placed between the package name and the @ character (see https://github.com/pypa/pipenv/pull/6282).