### PR TITLE
Add support for current Poetry versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   tests-ubuntu:
     name: "Test: py${{ matrix.python-version }}, Ubuntu"
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -21,25 +21,18 @@ jobs:
           tox-env: min
         - python-version: '3.6'
           os: ubuntu-20.04
-          tox-env: py
         - python-version: '3.7'
           os: ubuntu-22.04
-          tox-env: py
+        - python-version: '3.7'
+          tox-env: min-poetry
+          os: ubuntu-22.04
         - python-version: '3.8'
-          os: ubuntu-latest
-          tox-env: py
         - python-version: '3.9'
-          os: ubuntu-latest
-          tox-env: py
         - python-version: '3.10'
-          os: ubuntu-latest
-          tox-env: py
         - python-version: '3.11'
-          os: ubuntu-latest
-          tox-env: py
         - python-version: '3.12'
-          os: ubuntu-latest
-          tox-env: py
+        - python-version: '3.13'
+          tox-env: poetry
 
     steps:
     - uses: actions/checkout@v2
@@ -53,7 +46,7 @@ jobs:
       run: pip install tox
 
     - name: Run tests
-      run: tox -e ${{ matrix.tox-env }}
+      run: tox -e ${{ matrix.tox-env || 'py' }}
 
     - name: Run off-tox tests
       # https://github.com/scrapinghub/shub/issues/441
@@ -120,19 +113,17 @@ jobs:
         - python-version: '3.6'
           tox-env: min
         - python-version: '3.6'
-          tox-env: py
         - python-version: '3.7'
-          tox-env: py
+        - python-version: '3.7'
+          tox-env: min-poetry
         - python-version: '3.8'
-          tox-env: py
         - python-version: '3.9'
-          tox-env: py
         - python-version: '3.10'
-          tox-env: py
         - python-version: '3.11'
-          tox-env: py
         - python-version: '3.12'
-          tox-env: py
+        - python-version: '3.13'
+        - python-version: '3.13'
+          tox-env: poetry
 
     steps:
     - uses: actions/checkout@v2
@@ -146,4 +137,4 @@ jobs:
       run: pip install tox
 
     - name: Run tests
-      run: tox -e ${{ matrix.tox-env }}
+      run: tox -e ${{ matrix.tox-env || 'py' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,11 +56,10 @@ jobs:
         pip install .
         python -c "from shub.image.utils import get_docker_client; get_docker_client(validate=False)"
 
-    - name: Upload coverage report
-      run: |
-        curl -Os https://uploader.codecov.io/latest/linux/codecov
-        chmod +x codecov
-        ./codecov
+    - name: coverage
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   tests-macos:
     name: "Test: py${{ matrix.python-version }}, macOS"
@@ -103,6 +102,11 @@ jobs:
     - name: Run tests
       run: tox -e ${{ matrix.tox-env || 'py' }}
 
+    - name: coverage
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+
   tests-windows:
     name: "Test: py${{ matrix.python-version }}, Windows"
     runs-on: windows-latest
@@ -138,3 +142,8 @@ jobs:
 
     - name: Run tests
       run: tox -e ${{ matrix.tox-env || 'py' }}
+
+    - name: coverage
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,11 +80,11 @@ jobs:
           tox-env: min
           os: macos-13
         - python-version: '3.6'
-          tox-env: min-poetry
-          os: macos-13
-        - python-version: '3.6'
           os: macos-13
         - python-version: '3.7'
+          os: macos-13
+        - python-version: '3.7'
+          tox-env: min-poetry
           os: macos-13
         - python-version: '3.8'
           os: macos-13

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,22 +80,21 @@ jobs:
           tox-env: min
           os: macos-13
         - python-version: '3.6'
-          tox-env: py
+          tox-env: min-poetry
+          os: macos-13
+        - python-version: '3.6'
           os: macos-13
         - python-version: '3.7'
-          tox-env: py
           os: macos-13
         - python-version: '3.8'
-          tox-env: py
           os: macos-13
         - python-version: '3.9'
-          tox-env: py
         - python-version: '3.10'
-          tox-env: py
         - python-version: '3.11'
-          tox-env: py
         - python-version: '3.12'
-          tox-env: py
+        - python-version: '3.13'
+        - python-version: '3.13'
+          tox-env: poetry
 
     steps:
     - uses: actions/checkout@v2
@@ -109,7 +108,7 @@ jobs:
       run: pip install tox
 
     - name: Run tests
-      run: tox -e ${{ matrix.tox-env }}
+      run: tox -e ${{ matrix.tox-env || 'py' }}
 
   tests-windows:
     name: "Test: py${{ matrix.python-version }}, Windows"

--- a/docs/deploying.rst
+++ b/docs/deploying.rst
@@ -96,8 +96,8 @@ If you use `Poetry`_ you can specify your ``pyproject.toml``::
 This will use Poetry's ``export`` command to create a requirements.txt file. For
 Poetry >= 2.0 this command is no longer installed by default and needs to manually
 added as described in the
-`plugin's documentation<https://github.com/python-poetry/poetry-plugin-export>`_.
-If ``poetry.lock``does not exist yet, it will be created during this process.
+`plugin's documentation <https://github.com/python-poetry/poetry-plugin-export>`_.
+If ``poetry.lock`` does not exist yet, it will be created during this process.
 
 .. note::
 

--- a/docs/deploying.rst
+++ b/docs/deploying.rst
@@ -93,8 +93,11 @@ If you use `Poetry`_ you can specify your ``pyproject.toml``::
     requirements:
       file: pyproject.toml
 
-A ``poetry.lock`` file must be available, that will be used for determining the
-full requirements.
+This will use Poetry's ``export`` command to create a requirements.txt file. For
+Poetry >= 2.0 this command is no longer installed by default and needs to manually
+added as described in the
+`plugin's documentation<https://github.com/python-poetry/poetry-plugin-export>`_.
+If ``poetry.lock``does not exist yet, it will be created during this process.
 
 .. note::
 

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Operating System :: OS Independent',
         'Environment :: Console',
         'Topic :: Internet :: WWW/HTTP',

--- a/shub/deploy.py
+++ b/shub/deploy.py
@@ -17,7 +17,7 @@ from shub.config import SH_IMAGES_REGISTRY, list_targets_callback, load_shub_con
 from shub.exceptions import BadParameterException, NotFoundException, ShubException
 from shub.image.upload import upload_cmd
 from shub.utils import (create_default_setup_py, create_scrapinghub_yml_wizard,
-                        inside_project, make_deploy_request, run_python)
+                        inside_project, make_deploy_request, run_cmd, run_python)
 
 HELP = """
 Deploy the current folder's Scrapy project to Scrapy Cloud.
@@ -218,32 +218,7 @@ def _is_poetry(name):
 
 
 def _get_poetry_requirements():
-    try:
-        data = toml.load('poetry.lock')
-    except OSError:
-        raise ShubException('Please make sure the poetry lock file is present')
-    # Adapted from poetry 1.0.0a2 poetry/utils/exporter.py
-    lines = []
-    for package in data['package']:
-        source = package.get('source') or {}
-        source_type = source.get('type')
-        if source_type == 'git':
-            line = 'git+{}@{}#egg={}'.format(
-                source['url'], source['reference'], package['name']
-            )
-        elif source_type in ['directory', 'file']:
-            line = ''
-            line += source['url']
-        else:
-            line = '{}=={}'.format(package['name'], package['version'])
-
-            if source_type == 'legacy' and source['url']:
-                line += ' \\\n'
-                line += '    --index-url {}'.format(source['url'])
-
-        line += '\n'
-        lines.append(line)
-    return ''.join(lines)
+    return run_cmd([shutil.which("poetry"), "export", "--without-hashes", "-f", "requirements.txt"])
 
 
 def _build_egg():

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,3 +3,6 @@ pytest
 pytest-cov
 flake8
 pipenv
+cleo
+poetry-core
+poetry-plugin-export

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,8 +1,6 @@
+cleo
+flake8
+pipenv
 python-dateutil
 pytest
 pytest-cov
-flake8
-pipenv
-cleo
-poetry-core
-poetry-plugin-export

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import sys
 import unittest
 from unittest.mock import patch, Mock
@@ -456,12 +457,14 @@ class DeployFilesTest(unittest.TestCase):
             self.assertTrue(mock_is_fresh.called)
             self.assertTrue(mock_check_output.called)
 
+            path_prefix = "C:/" if platform.system() == "Windows" else ""
+
             self.assertEqual(
                 files['requirements'][0],
                 (
-                    'dir-package @ file:///path/to/package ; '
+                    f'dir-package @ file:///{path_prefix}path/to/package ; '
                     'python_version == "2.7" or python_version >= "3.4"\n'
-                    'file-package @ file:///path/to/package.tar.gz ; '
+                    f'file-package @ file:///{path_prefix}path/to/package.tar.gz ; '
                     'python_version == "2.7" or python_version >= "3.4"\n'
                     'package==0.0.0 ; '
                     'python_version == "2.7" or python_version >= "3.4"\n'

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -549,15 +549,21 @@ class DeployFilesTest(unittest.TestCase):
             with self.assertRaises(ShubException) as cm:
                 self._deploy(req='pyproject.toml')
 
-            try:
-                version("poetry")
-            except PackageNotFoundError:
-                self.assertIn(
-                    "poetry executable not found",
-                    cm.exception.message,
-                )
-            else:
+            if sys.version_info < (3, 8):
                 self.assertIn(
                     "The Poetry configuration is invalid",
                     cm.exception.message,
                 )
+            else:
+                try:
+                    version("poetry")
+                except PackageNotFoundError:
+                    self.assertIn(
+                        "poetry executable not found",
+                        cm.exception.message,
+                    )
+                else:
+                    self.assertIn(
+                        "The Poetry configuration is invalid",
+                        cm.exception.message,
+                    )

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import unittest
-from importlib.metadata import version, PackageNotFoundError
 from unittest.mock import patch, Mock
 
 from packaging.version import parse
@@ -20,12 +19,17 @@ from shub.utils import create_default_setup_py, _SETUP_PY_TEMPLATE, STDOUT_ENCOD
 from .utils import AssertInvokeRaisesMixin, mock_conf
 
 try:
-    POETRY_VERSION = parse(version("poetry"))
-except PackageNotFoundError:
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError:
+    POETRY_VERSION = None
+else:
     try:
-        POETRY_VERSION = parse(version("poetry-core"))
+        POETRY_VERSION = parse(version("poetry"))
     except PackageNotFoundError:
-        POETRY_VERSION = None
+        try:
+            POETRY_VERSION = parse(version("poetry-core"))
+        except PackageNotFoundError:
+            POETRY_VERSION = None
 
 VALID_SCRAPY_CFG = """
 [settings]

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -551,7 +551,7 @@ class DeployFilesTest(unittest.TestCase):
 
             if sys.version_info < (3, 8):
                 self.assertIn(
-                    "The Poetry configuration is invalid",
+                    "poetry executable not found",
                     cm.exception.message,
                 )
             else:

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -455,10 +455,15 @@ class DeployFilesTest(unittest.TestCase):
             self.assertEqual(
                 files['requirements'][0],
                 (
-                    'dir-package @ file:///path/to/package ; python_version == "2.7" or python_version >= "3.4"\n'
-                    'file-package @ file:///path/to/package.tar.gz ; python_version == "2.7" or python_version >= "3.4"\n'
-                    'package==0.0.0 ; python_version == "2.7" or python_version >= "3.4"\n'
-                    'vcs-package @ git+https://github.com/vcs/package.git@master ; python_version == "2.7" or python_version >= "3.4"'
+                    'dir-package @ file:///path/to/package ; '
+                    'python_version == "2.7" or python_version >= "3.4"\n'
+                    'file-package @ file:///path/to/package.tar.gz ; '
+                    'python_version == "2.7" or python_version >= "3.4"\n'
+                    'package==0.0.0 ; '
+                    'python_version == "2.7" or python_version >= "3.4"\n'
+                    'vcs-package @ '
+                    'git+https://github.com/vcs/package.git@master ; '
+                    'python_version == "2.7" or python_version >= "3.4"'
                 ),
             )
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
 [testenv:min-poetry]
 basepython = python3.7
 deps =
-    {[testenv:min]deps}
+    {[testenv]deps}
     poetry-core<2
 
 [testenv:poetry]

--- a/tox.ini
+++ b/tox.ini
@@ -11,11 +11,13 @@ commands =
     pytest --cov=shub --cov-report=term-missing --cov-report=html --cov-report=xml {posargs:shub tests}
 
 [testenv:min]
+basepython = python3.6
 deps =
     {[testenv]deps}
     pipenv<2024.3.0
 
 [testenv:min-poetry]
+basepython = python3.6
 deps =
     {[testenv:min]deps}
     poetry-core<2

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,py
+envlist = flake8,min,min-poetry,py,poetry
 
 [testenv]
 basepython = python3
@@ -14,6 +14,17 @@ commands =
 deps =
     {[testenv]deps}
     pipenv<2024.3.0
+
+[testenv:min-poetry]
+deps =
+    {[testenv:min]deps}
+    poetry-core<2
+
+[testenv:poetry]
+deps =
+    {[testenv:min]deps}
+    poetry-core
+    poetry-plugin-export
 
 [testenv:freeze]
 install_command =

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps =
     pipenv<2024.3.0
 
 [testenv:min-poetry]
-basepython = python3.6
+basepython = python3.7
 deps =
     {[testenv:min]deps}
     poetry-core<2


### PR DESCRIPTION
The previous lockfile parser did not work reliably for Poetry 1.2 and later due to the new lockfile format (e.g., it did not take markers into consideration). This solution should work for all Poetry versions since it uses the `poetry export` command to generate a `requirements.txt` file.

I encountered an issue where shub deploy failed with a requirement error because it attempted to install `pywin32`. This happened because the marker `sys_platform == "win32"` was missing from the generated requirements.txt file.

I’m not sure if it still makes sense to test the conversion from poetry.lock to requirements.txt, as Poetry's test suite already covers this extensively. I adapted the test, but in my opinion, it could be dropped.

The biggest caveat of the new implementation is that users need to have Poetry installed. However, I think this is a safe assumption for this scenario. Or should the old implementation serve as a fallback if the `poetry` command is not found?

Let me know if supporting current Poetry versions is desirable but this solution is not sufficient—I’m happy to refine it or explore alternative approaches.