### PR TITLE
Fix API key setting page URL

### DIFF
--- a/shub/login.py
+++ b/shub/login.py
@@ -39,7 +39,7 @@ def cli():
 def _get_apikey(suggestion='', endpoint=None):
     suggestion_txt = ' (%s)' % suggestion if suggestion else ''
     click.echo(
-        "Enter your API key from https://app.zyte.com/account/apikey"
+        "Enter your API key from https://app.zyte.com/o/settings/apikey"
     )
     while True:
         key = input('API key%s: ' % suggestion_txt) or suggestion


### PR DESCRIPTION
Shub login command specifies that the scrapy cloud API key is at https://app.zyte.com/account/apikey but it's actually zyte API key page. Scrapy cloud api keys are in https://app.zyte.com/o/settings/apikey.

This PR fixes this reference.