### PR TITLE
Support for reading SHUB_APIKEY from .env file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,13 @@
 Changes
 =======
 
+2.18.0 (unreleased)
+===================
+
+-   Load the ``SHUB_APIKEY`` environment variable from a ``.env`` file via
+    `python-dotenv`. Use the new ``--dotenv-path`` option to point ``shub`` at
+    a file other than the default ``.env``.
+
 2.17.1 (2026-04-21)
 ===================
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -130,7 +130,8 @@ file and let ``shub`` load it:
 
     SHUB_APIKEY=0bbf4f0f691e0d9378ae00ca7bcf7f0c
 
-By default ``shub`` reads the ``.env`` file in the current directory. Use the
+By default ``shub`` reads the nearest ``.env`` file, looking in the current
+directory and then walking up through its parent directories. Use the
 ``--dotenv-path`` option to point it at a different file::
 
     shub --dotenv-path /path/to/myenv deploy

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -123,7 +123,10 @@ On Windows::
     SET SHUB_APIKEY=0bbf4f0f691e0d9378ae00ca7bcf7f0c
 
 Instead of exporting the variable yourself, you can store it in a ``.env``
-file and let ``shub`` load it::
+file and let ``shub`` load it:
+
+.. code-block:: bash
+    :caption: :file:`.env`
 
     SHUB_APIKEY=0bbf4f0f691e0d9378ae00ca7bcf7f0c
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -122,6 +122,20 @@ On Windows::
 
     SET SHUB_APIKEY=0bbf4f0f691e0d9378ae00ca7bcf7f0c
 
+Instead of exporting the variable yourself, you can store it in a ``.env``
+file and let ``shub`` load it::
+
+    SHUB_APIKEY=0bbf4f0f691e0d9378ae00ca7bcf7f0c
+
+By default ``shub`` reads the ``.env`` file in the current directory. Use the
+``--dotenv-path`` option to point it at a different file::
+
+    shub --dotenv-path /path/to/myenv deploy
+
+Only the ``SHUB_APIKEY`` variable is read from the file; any other variables
+are ignored. A ``SHUB_APIKEY`` already set in the environment takes precedence
+over the value in the file.
+
 You can also parametrize global ``scrapinghub.yml`` file location with
 ``SHUB_GLOBAL_CONFIG`` environment variable (default ``~/.scrapinghub.yml``).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
 	'importlib-metadata; python_version < "3.10"',
 	"packaging",
 	"pip",
+	"python-dotenv>=1.0.0",
 	"PyYAML",
 	"requests",
 	"retrying",

--- a/shub/tool.py
+++ b/shub/tool.py
@@ -1,6 +1,8 @@
 import importlib
+import os
 
 import click
+from dotenv import dotenv_values
 
 import shub
 from shub.utils import update_available
@@ -23,10 +25,29 @@ For usage and help on a specific command, run it with a --help flag, e.g.:
 CONTEXT_SETTINGS = {'help_option_names': ['-h', '--help']}
 
 
+def _load_dotenv_apikey(dotenv_path: str | None) -> None:
+    """Load SHUB_APIKEY from a .env file into the environment.
+
+    Only the SHUB_APIKEY variable is read from the file; any other variables are ignored.
+    A SHUB_APIKEY already present in the environment takes precedence over the value in
+    the file. When ``dotenv_path`` is None, python-dotenv looks for a ``.env`` file in
+    the current directory.
+    """
+    if 'SHUB_APIKEY' in os.environ:
+        return
+    apikey = dotenv_values(dotenv_path).get('SHUB_APIKEY')
+    if apikey:
+        os.environ['SHUB_APIKEY'] = apikey
+
+
 @click.group(help=HELP, short_help=SHORT_HELP, epilog=EPILOG,
              context_settings=CONTEXT_SETTINGS)
+@click.option('--dotenv-path', default=None, type=click.Path(dir_okay=False),
+              help="Path to a .env file to read the SHUB_APIKEY environment variable from."
+                   " Defaults to the '.env' file in the current directory.")
 @click.version_option(shub.__version__)
-def cli():
+def cli(dotenv_path: str | None) -> None:
+    _load_dotenv_apikey(dotenv_path)
     update_url = update_available()
     if update_url:
         click.echo("INFO: A newer version of shub is available. Update "

--- a/shub/tool.py
+++ b/shub/tool.py
@@ -2,7 +2,7 @@ import importlib
 import os
 
 import click
-from dotenv import dotenv_values
+from dotenv import dotenv_values, find_dotenv
 
 import shub
 from shub.utils import update_available
@@ -30,12 +30,12 @@ def _load_dotenv_apikey(dotenv_path: str | None) -> None:
 
     Only the SHUB_APIKEY variable is read from the file; any other variables are ignored.
     A SHUB_APIKEY already present in the environment takes precedence over the value in
-    the file. When ``dotenv_path`` is None, the ``.env`` file in the current directory
-    is used.
+    the file. When ``dotenv_path`` is None, the nearest ``.env`` file in the current
+    directory or its parents is used.
     """
     if 'SHUB_APIKEY' in os.environ:
         return
-    apikey = dotenv_values(dotenv_path or ".env").get('SHUB_APIKEY')
+    apikey = dotenv_values(dotenv_path or find_dotenv(usecwd=True)).get('SHUB_APIKEY')
     if apikey:
         os.environ['SHUB_APIKEY'] = apikey
 

--- a/shub/tool.py
+++ b/shub/tool.py
@@ -30,12 +30,12 @@ def _load_dotenv_apikey(dotenv_path: str | None) -> None:
 
     Only the SHUB_APIKEY variable is read from the file; any other variables are ignored.
     A SHUB_APIKEY already present in the environment takes precedence over the value in
-    the file. When ``dotenv_path`` is None, python-dotenv looks for a ``.env`` file in
-    the current directory.
+    the file. When ``dotenv_path`` is None, the ``.env`` file in the current directory
+    is used.
     """
     if 'SHUB_APIKEY' in os.environ:
         return
-    apikey = dotenv_values(dotenv_path).get('SHUB_APIKEY')
+    apikey = dotenv_values(dotenv_path or ".env").get('SHUB_APIKEY')
     if apikey:
         os.environ['SHUB_APIKEY'] = apikey
 

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -29,6 +29,18 @@ def test_load_dotenv_apikey_default_path(tmp_path, monkeypatch):
     assert os.environ['SHUB_APIKEY'] == 'FROMDOTENV'
 
 
+def test_load_dotenv_apikey_parent_dir(tmp_path, monkeypatch):
+    monkeypatch.delenv('SHUB_APIKEY', raising=False)
+    (tmp_path / '.env').write_text('SHUB_APIKEY=FROMPARENT\n')
+    subdir = tmp_path / 'project' / 'subdir'
+    subdir.mkdir(parents=True)
+    monkeypatch.chdir(subdir)
+
+    _load_dotenv_apikey(None)
+
+    assert os.environ['SHUB_APIKEY'] == 'FROMPARENT'
+
+
 def test_load_dotenv_apikey_custom_path(tmp_path, monkeypatch):
     monkeypatch.delenv('SHUB_APIKEY', raising=False)
     env_file = tmp_path / 'custom.env'

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -1,0 +1,80 @@
+import os
+from unittest import mock
+
+import pytest
+from click.testing import CliRunner
+
+from shub.tool import _load_dotenv_apikey, cli
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def no_update_check():
+    # Avoid network calls from the cli group callback during tests.
+    with mock.patch('shub.tool.update_available', return_value=None):
+        yield
+
+
+def test_load_dotenv_apikey_default_path(tmp_path, monkeypatch):
+    monkeypatch.delenv('SHUB_APIKEY', raising=False)
+    (tmp_path / '.env').write_text('SHUB_APIKEY=FROMDOTENV\n')
+    monkeypatch.chdir(tmp_path)
+
+    _load_dotenv_apikey(None)
+
+    assert os.environ['SHUB_APIKEY'] == 'FROMDOTENV'
+
+
+def test_load_dotenv_apikey_custom_path(tmp_path, monkeypatch):
+    monkeypatch.delenv('SHUB_APIKEY', raising=False)
+    env_file = tmp_path / 'custom.env'
+    env_file.write_text('SHUB_APIKEY=CUSTOMKEY\n')
+
+    _load_dotenv_apikey(str(env_file))
+
+    assert os.environ['SHUB_APIKEY'] == 'CUSTOMKEY'
+
+
+def test_load_dotenv_apikey_only_reads_apikey(tmp_path, monkeypatch):
+    monkeypatch.delenv('SHUB_APIKEY', raising=False)
+    monkeypatch.delenv('OTHER_VAR', raising=False)
+    env_file = tmp_path / 'custom.env'
+    env_file.write_text('SHUB_APIKEY=ONLYTHIS\nOTHER_VAR=ignored\n')
+
+    _load_dotenv_apikey(str(env_file))
+
+    assert os.environ['SHUB_APIKEY'] == 'ONLYTHIS'
+    assert 'OTHER_VAR' not in os.environ
+
+
+def test_existing_env_takes_precedence(tmp_path, monkeypatch):
+    monkeypatch.setenv('SHUB_APIKEY', 'FROMENV')
+    env_file = tmp_path / 'custom.env'
+    env_file.write_text('SHUB_APIKEY=FROMDOTENV\n')
+
+    _load_dotenv_apikey(str(env_file))
+
+    assert os.environ['SHUB_APIKEY'] == 'FROMENV'
+
+
+def test_missing_dotenv_file_is_noop(tmp_path, monkeypatch):
+    monkeypatch.delenv('SHUB_APIKEY', raising=False)
+
+    _load_dotenv_apikey(str(tmp_path / 'does-not-exist.env'))
+
+    assert 'SHUB_APIKEY' not in os.environ
+
+
+def test_cli_dotenv_path_option(runner, tmp_path, monkeypatch):
+    monkeypatch.delenv('SHUB_APIKEY', raising=False)
+    env_file = tmp_path / 'custom.env'
+    env_file.write_text('SHUB_APIKEY=CLIKEY\n')
+
+    result = runner.invoke(cli, ['--dotenv-path', str(env_file), 'version'])
+
+    assert result.exit_code == 0, result.output
+    assert os.environ['SHUB_APIKEY'] == 'CLIKEY'

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ basepython = python3.10
 deps =
     {[testenv]deps}
     pipenv<2024.3.0
+    python-dotenv==1.0.0
 
 [testenv:min-poetry]
 basepython = python3.10


### PR DESCRIPTION
Since we only care about `SHUB_APIKEY` this PR uses `dotenv_values` instead of `load_dotenv` to avoid overriding other keys.