### PR TITLE
dotenv support for library use

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,13 @@
 Changes
 =======
 
+Unreleased
+==========
+
+-   ``shub.config.load_shub_config()`` now also reads ``SHUB_APIKEY`` from the
+    nearest ``.env`` file, not just the ``shub`` CLI. Previously this only
+    worked when invoking the ``shub`` command.
+
 2.18.0 (2026-06-19)
 ===================
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -140,6 +140,12 @@ Only the ``SHUB_APIKEY`` variable is read from the file; any other variables
 are ignored. A ``SHUB_APIKEY`` already set in the environment takes precedence
 over the value in the file.
 
+This ``.env`` lookup is not limited to the ``shub`` command: it is also
+performed by ``shub.config.load_shub_config()``, so code that uses shub as a
+library (instead of invoking the CLI) picks up ``SHUB_APIKEY`` from the
+nearest ``.env`` file too. Pass ``load_env=False`` to ``load_shub_config()``
+to skip both the environment variable and the ``.env`` file lookup.
+
 You can also parametrize global ``scrapinghub.yml`` file location with
 ``SHUB_GLOBAL_CONFIG`` environment variable (default ``~/.scrapinghub.yml``).
 

--- a/shub/config.py
+++ b/shub/config.py
@@ -492,7 +492,7 @@ def _migrate_and_load_scrapy_cfg(conf):
         click.echo(PROJECT_MIGRATION_OK_BANNER, err=True)
 
 
-def _load_dotenv_apikey(dotenv_path=None):
+def _load_dotenv_apikey(dotenv_path: str | None = None) -> None:
     """Load SHUB_APIKEY from a .env file into the environment.
 
     Only the SHUB_APIKEY variable is read from the file; any other variables are ignored.

--- a/shub/config.py
+++ b/shub/config.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse, urlunparse
 
 import click
 import yaml
+from dotenv import dotenv_values, find_dotenv
 
 from shub import DOCS_LINK, CONFIG_DOCS_LINK
 from shub.exceptions import (BadParameterException, BadConfigException,
@@ -491,6 +492,21 @@ def _migrate_and_load_scrapy_cfg(conf):
         click.echo(PROJECT_MIGRATION_OK_BANNER, err=True)
 
 
+def _load_dotenv_apikey(dotenv_path=None):
+    """Load SHUB_APIKEY from a .env file into the environment.
+
+    Only the SHUB_APIKEY variable is read from the file; any other variables are ignored.
+    A SHUB_APIKEY already present in the environment takes precedence over the value in
+    the file. When ``dotenv_path`` is None, the nearest ``.env`` file in the current
+    directory or its parents is used.
+    """
+    if 'SHUB_APIKEY' in os.environ:
+        return
+    apikey = dotenv_values(dotenv_path or find_dotenv(usecwd=True)).get('SHUB_APIKEY')
+    if apikey:
+        os.environ['SHUB_APIKEY'] = apikey
+
+
 def load_shub_config(load_global=True, load_local=True, load_env=True):
     """
     Return a ShubConfig instance with ~/.scrapinghub.yml and the closest
@@ -507,8 +523,10 @@ def load_shub_config(load_global=True, load_local=True, load_env=True):
             conf.load_file(closest_sh_yml)
         else:
             _migrate_and_load_scrapy_cfg(conf)
-    if load_env and 'SHUB_APIKEY' in os.environ:
-        conf.apikeys['default'] = os.environ['SHUB_APIKEY']
+    if load_env:
+        _load_dotenv_apikey()
+        if 'SHUB_APIKEY' in os.environ:
+            conf.apikeys['default'] = os.environ['SHUB_APIKEY']
     return conf
 
 

--- a/shub/tool.py
+++ b/shub/tool.py
@@ -1,10 +1,9 @@
 import importlib
-import os
 
 import click
-from dotenv import dotenv_values, find_dotenv
 
 import shub
+from shub.config import _load_dotenv_apikey
 from shub.utils import update_available
 
 
@@ -23,21 +22,6 @@ For usage and help on a specific command, run it with a --help flag, e.g.:
 """
 
 CONTEXT_SETTINGS = {'help_option_names': ['-h', '--help']}
-
-
-def _load_dotenv_apikey(dotenv_path: str | None) -> None:
-    """Load SHUB_APIKEY from a .env file into the environment.
-
-    Only the SHUB_APIKEY variable is read from the file; any other variables are ignored.
-    A SHUB_APIKEY already present in the environment takes precedence over the value in
-    the file. When ``dotenv_path`` is None, the nearest ``.env`` file in the current
-    directory or its parents is used.
-    """
-    if 'SHUB_APIKEY' in os.environ:
-        return
-    apikey = dotenv_values(dotenv_path or find_dotenv(usecwd=True)).get('SHUB_APIKEY')
-    if apikey:
-        os.environ['SHUB_APIKEY'] = apikey
 
 
 @click.group(help=HELP, short_help=SHORT_HELP, epilog=EPILOG,


### PR DESCRIPTION
Currently dotenv support covers only `shub` CLI invocations, but not library usage such as:

```python
import shub.config

config = shub.config.load_shub_config()
apikey = config.apikeys.get("default")
```